### PR TITLE
U_i = A^n

### DIFF
--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -9,13 +9,14 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_) renaming (ℙ to Powerset)
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HLevels
 
 open import Cubical.Functions.Logic using (⇒∶_⇐∶_)
 open import Cubical.Functions.Embedding
 
 open import Cubical.HITs.SetQuotients as SQ
 open import Cubical.HITs.PropositionalTruncation as PT
-open import Cubical.Data.Nat
+open import Cubical.Data.Nat using (ℕ; _+_)
 open import Cubical.Data.FinData
 open import Cubical.Data.Sigma
 
@@ -27,37 +28,35 @@ open import Cubical.Algebra.Module.Instances.FinVec
 open import Cubical.Relation.Nullary.Base using (¬_)
 open import Cubical.Relation.Binary
 
+open import Cubical.Tactics.CommRingSolver.Reflection
+
 open import SyntheticGeometry.Spec
 open import SyntheticGeometry.Open
 open import SyntheticGeometry.SQC
-
-open import Cubical.Tactics.CommRingSolver.Reflection
 
 private variable ℓ : Level
 
 module _ (k : CommRing ℓ) (n : ℕ) where
   module k = CommRingStr (snd k)
   module 𝔸ⁿ⁺¹ = LeftModuleStr (snd (FinVecLeftModule (CommRing→Ring k) {n = n + 1}))
+  open k hiding (_+_)
+  open 𝔸ⁿ⁺¹ hiding (_+_)
+  open Units k
 
   𝔸ⁿ⁺¹ = FinVec ⟨ k ⟩ (n + 1)
 
   0𝔸ⁿ⁺¹ : 𝔸ⁿ⁺¹
-  0𝔸ⁿ⁺¹ = replicateFinVec (n + 1) k.0r
+  0𝔸ⁿ⁺¹ = replicateFinVec (n + 1) 0r
 
   𝔸ⁿ⁺¹-0 = Σ[ x ∈ 𝔸ⁿ⁺¹ ] ¬ (x ≡ 0𝔸ⁿ⁺¹)
 
   linear-equivalent : (x y : 𝔸ⁿ⁺¹) → Type _
   linear-equivalent x y =
     Σ[ c ∈ ⟨ k ⟩ ] (c ∈ (k ˣ)) × (c ⋆ x ≡ y)
-    where
-    open 𝔸ⁿ⁺¹ using (_⋆_)
 
   module _ where
     open BinaryRelation
     open isEquivRel
-    open k
-    open 𝔸ⁿ⁺¹
-    open Units k
 
     isEquivRel-lin-eq : isEquivRel linear-equivalent
 
@@ -68,17 +67,17 @@ module _ (k : CommRing ℓ) (n : ℕ) where
       Units.RˣInvClosed k c ,
       ( c⁻¹ ⋆ y          ≡⟨ sym (cong (c⁻¹ ⋆_) cx≡y) ⟩
         c⁻¹ ⋆ (c ⋆ x)    ≡⟨ sym (⋆Assoc _ _ _) ⟩
-        (c⁻¹ k.· c) ⋆ x  ≡⟨ cong (_⋆ x) (·-linv c) ⟩
-        k.1r ⋆ x         ≡⟨ ⋆IdL _  ⟩
+        (c⁻¹ · c) ⋆ x    ≡⟨ cong (_⋆ x) (·-linv c) ⟩
+        1r ⋆ x           ≡⟨ ⋆IdL _  ⟩
         x                ∎ )
       where
         instance _ = c∈kˣ
         c⁻¹ = c ⁻¹
 
     transitive isEquivRel-lin-eq x y z (c , c∈kˣ , cx≡y) (d , d∈kˣ , dy≡z) =
-      d k.· c ,
+      d · c ,
       RˣMultClosed d c ,
-      ( ((d k.· c) ⋆ x)  ≡⟨ ⋆Assoc _ _ _ ⟩
+      ( ((d · c) ⋆ x)    ≡⟨ ⋆Assoc _ _ _ ⟩
         (d ⋆ (c ⋆ x))    ≡⟨ cong (_ ⋆_) cx≡y ⟩
         (d ⋆ y)          ≡⟨ dy≡z ⟩
         z                ∎ )
@@ -89,6 +88,7 @@ module _ (k : CommRing ℓ) (n : ℕ) where
 
     -- Note: linear-equivalent is not prop-valued as a relation on 𝔸ⁿ⁺¹
     -- but it is if we restrict to 𝔸ⁿ⁺¹-0 and assume k to be local and SQC.
+    -- It doesn't seem like we need this for now.
 
   ℙ : Type _
   ℙ = 𝔸ⁿ⁺¹-0 / (on fst linear-equivalent)
@@ -109,7 +109,7 @@ Construct an open covering by affine schemes.
                   (⇒∶ step2 (fst x) (fst y) x~y
                    ⇐∶ step2 (fst y) (fst x) (symmetric _ _ x~y))
         where
-          step1 : (u v w : ⟨ k ⟩) → (u ∈ k ˣ) → (v ∈ k ˣ) → u k.· v ≡ w → w ∈ k ˣ
+          step1 : (u v w : ⟨ k ⟩) → (u ∈ k ˣ) → (v ∈ k ˣ) → u · v ≡ w → w ∈ k ˣ
           step1 u v w u∈kˣ v∈kˣ p = subst (_∈ k ˣ) p (Units.RˣMultClosed k u v)
             where
               instance
@@ -120,7 +120,7 @@ Construct an open covering by affine schemes.
           open BinaryRelation.isEquivRel isEquivRel-lin-eq
 
     embedded-𝔸ⁿ : Type ℓ
-    embedded-𝔸ⁿ = Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ k.1r
+    embedded-𝔸ⁿ = Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ 1r
 
     module _
       (k-local : isLocal k)
@@ -145,15 +145,32 @@ Construct an open covering by affine schemes.
           c ⋆ x    ≡⟨ cx≡y ⟩
           y        ∎
           where
-          open 𝔸ⁿ⁺¹
-          open k
-          c≡1 : c ≡ k.1r
+          c≡1 : c ≡ 1r
           c≡1 =
-            c           ≡⟨ sym (·IdR _) ⟩
-            c k.· 1r    ≡⟨ cong (_ k.·_) (sym xi≡1) ⟩
-            c k.· x i   ≡⟨ funExt⁻ cx≡y i ⟩
-            y i         ≡⟨ yi≡1 ⟩
-            1r          ∎
+            c         ≡⟨ sym (·IdR _) ⟩
+            c · 1r    ≡⟨ cong (_ ·_) (sym xi≡1) ⟩
+            c · x i   ≡⟨ funExt⁻ cx≡y i ⟩
+            y i       ≡⟨ yi≡1 ⟩
+            1r        ∎
+
+      ι-embedding : isEmbedding ι
+      ι-embedding = injEmbedding squash/ (ι-injective _ _)
+
+      imι⊆U : (x : embedded-𝔸ⁿ) → fst (fst (U (ι x)))
+      imι⊆U (x , xi≡1) = subst (_∈ (k ˣ)) (sym xi≡1) RˣContainsOne
+
+      U⊆imι : (p : ℙ) → fst (fst (U p)) → fiber ι p
+      U⊆imι =
+        elimProp
+          (λ p → isProp→ (injective→hasPropFibers squash/ (ι-injective _ _) p))
+          λ{ (x , _) xi∈kˣ@(c , xic≡1) →
+              (c ⋆ x , ·Comm c (x i) ∙ xic≡1) ,
+              eq/ _ _ ( x i , xi∈kˣ ,
+                ( x i ⋆ (c ⋆ x)    ≡⟨ sym (⋆Assoc _ _ _) ⟩
+                  (x i · c) ⋆ x    ≡⟨ cong (_⋆ _) xic≡1 ⟩
+                  1r ⋆ x           ≡⟨ ⋆IdL _ ⟩
+                  x                ∎ ) )}
+
 
   covering : isLocal k → sqc-over-itself k → (p : ℙ) → ∃[ i ∈ Fin (n + 1) ] ⟨ fst (U i p) ⟩
   covering k-local k-sqc =

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -25,6 +25,7 @@ open import Cubical.Algebra.Module
 open import Cubical.Algebra.Module.Instances.FinVec
 
 open import Cubical.Relation.Nullary.Base using (¬_)
+open import Cubical.Relation.Binary
 
 open import SyntheticGeometry.Spec
 open import SyntheticGeometry.Open
@@ -51,20 +52,40 @@ module _ (k : CommRing ℓ) (n : ℕ) where
     where
     open 𝔸ⁿ⁺¹ using (_⋆_)
 
-  linear-equivalence-sym : (x y : 𝔸ⁿ⁺¹) → linear-equivalent x y → linear-equivalent y x
-  linear-equivalence-sym x y (c , c∈kˣ , cx≡y) =
-    c⁻¹ ,
-    Units.RˣInvClosed k c ,
-    ( c⁻¹ ⋆ y          ≡⟨ sym (cong (c⁻¹ ⋆_) cx≡y) ⟩
-      c⁻¹ ⋆ (c ⋆ x)    ≡⟨ sym (⋆Assoc _ c _) ⟩
-      (c⁻¹ k.· c) ⋆ x  ≡⟨ cong (_⋆ x) ((Units.·-linv k c)) ⟩
-      k.1r ⋆ x         ≡⟨ ⋆IdL _  ⟩
-      x                ∎ )
-    where
-      open k
-      open 𝔸ⁿ⁺¹
-      instance _ = c∈kˣ
-      c⁻¹ = fst c∈kˣ
+  module _ where
+    open BinaryRelation
+    open isEquivRel
+    open k
+    open 𝔸ⁿ⁺¹
+    open Units k
+
+    isEquivRel-lin-eq : isEquivRel linear-equivalent
+
+    reflexive isEquivRel-lin-eq x = 1r , RˣContainsOne , (⋆IdL _)
+
+    symmetric isEquivRel-lin-eq x y (c , c∈kˣ , cx≡y) =
+      c⁻¹ ,
+      Units.RˣInvClosed k c ,
+      ( c⁻¹ ⋆ y          ≡⟨ sym (cong (c⁻¹ ⋆_) cx≡y) ⟩
+        c⁻¹ ⋆ (c ⋆ x)    ≡⟨ sym (⋆Assoc _ _ _) ⟩
+        (c⁻¹ k.· c) ⋆ x  ≡⟨ cong (_⋆ x) (·-linv c) ⟩
+        k.1r ⋆ x         ≡⟨ ⋆IdL _  ⟩
+        x                ∎ )
+      where
+        instance _ = c∈kˣ
+        c⁻¹ = c ⁻¹
+
+    transitive isEquivRel-lin-eq x y z (c , c∈kˣ , cx≡y) (d , d∈kˣ , dy≡z) =
+      d k.· c ,
+      RˣMultClosed d c ,
+      ( ((d k.· c) ⋆ x)  ≡⟨ ⋆Assoc _ _ _ ⟩
+        (d ⋆ (c ⋆ x))    ≡⟨ cong (_ ⋆_) cx≡y ⟩
+        (d ⋆ y)          ≡⟨ dy≡z ⟩
+        z                ∎ )
+      where
+        instance
+          _ = c∈kˣ
+          _ = d∈kˣ
 
   ℙ : Type _
   ℙ = 𝔸ⁿ⁺¹-0 / (λ x y → linear-equivalent (fst x) (fst y))
@@ -82,8 +103,8 @@ Construct an open covering by affine schemes.
             λ x y x~y
               → qc-open-≡
                   k _ _
-                  (⇒∶ (step2 (fst x) (fst y) x~y)
-                   ⇐∶ step2 (fst y) (fst x) (linear-equivalence-sym _ _ x~y))
+                  (⇒∶ step2 (fst x) (fst y) x~y
+                   ⇐∶ step2 (fst y) (fst x) (symmetric _ _ x~y))
         where
           step1 : (u v w : ⟨ k ⟩) → (u ∈ k ˣ) → (v ∈ k ˣ) → u k.· v ≡ w → w ∈ k ˣ
           step1 u v w u∈kˣ v∈kˣ p = subst (_∈ k ˣ) p (Units.RˣMultClosed k u v)
@@ -93,6 +114,7 @@ Construct an open covering by affine schemes.
                 _ = v∈kˣ
           step2 : (x y : _) → linear-equivalent x y → x i ∈ k ˣ → y i ∈ k ˣ
           step2 x y (c , c∈kˣ , cx≡y) xi∈kˣ = step1 c (x i) (y i) c∈kˣ xi∈kˣ (funExt⁻ cx≡y i)
+          open BinaryRelation.isEquivRel isEquivRel-lin-eq
 
     embedded-𝔸ⁿ : Type ℓ
     embedded-𝔸ⁿ = Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ k.1r

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -21,6 +21,8 @@ open import Cubical.Data.Sigma
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRing.LocalRing
+open import Cubical.Algebra.Module
+open import Cubical.Algebra.Module.Instances.FinVec
 
 open import Cubical.Relation.Nullary.Base using (¬_)
 
@@ -34,6 +36,7 @@ private variable ℓ : Level
 
 module _ (k : CommRing ℓ) (n : ℕ) where
   module k = CommRingStr (snd k)
+  module 𝔸ⁿ⁺¹ = LeftModuleStr (snd (FinVecLeftModule (CommRing→Ring k) {n = n + 1}))
 
   𝔸ⁿ⁺¹ = FinVec ⟨ k ⟩ (n + 1)
 
@@ -44,19 +47,22 @@ module _ (k : CommRing ℓ) (n : ℕ) where
 
   linear-equivalent : (x y : 𝔸ⁿ⁺¹) → Type _
   linear-equivalent x y =
-    Σ[ c ∈ ⟨ k ⟩ ] (c ∈ (k ˣ)) × ((i : Fin (n + 1)) → c k.· (x i) ≡ y i)
+    Σ[ c ∈ ⟨ k ⟩ ] (c ∈ (k ˣ)) × (c ⋆ x ≡ y)
+    where
+    open 𝔸ⁿ⁺¹ using (_⋆_)
 
   linear-equivalence-sym : (x y : 𝔸ⁿ⁺¹) → linear-equivalent x y → linear-equivalent y x
   linear-equivalence-sym x y (c , c∈kˣ , cx≡y) =
     c⁻¹ ,
     Units.RˣInvClosed k c ,
-    λ i → c⁻¹ k.· y i          ≡⟨ sym (cong (c⁻¹ k.·_) (cx≡y i)) ⟩
-          c⁻¹ k.· (c k.· x i)  ≡⟨ ·Assoc _ c _ ⟩
-          (c⁻¹ k.· c) k.· x i  ≡⟨ cong (k._· x i) (Units.·-linv k c) ⟩
-          k.1r k.· x i         ≡⟨ ·IdL _  ⟩
-          x i                  ∎
+    ( c⁻¹ ⋆ y          ≡⟨ sym (cong (c⁻¹ ⋆_) cx≡y) ⟩
+      c⁻¹ ⋆ (c ⋆ x)    ≡⟨ sym (⋆Assoc _ c _) ⟩
+      (c⁻¹ k.· c) ⋆ x  ≡⟨ cong (_⋆ x) ((Units.·-linv k c)) ⟩
+      k.1r ⋆ x         ≡⟨ ⋆IdL _  ⟩
+      x                ∎ )
     where
       open k
+      open 𝔸ⁿ⁺¹
       instance _ = c∈kˣ
       c⁻¹ = fst c∈kˣ
 
@@ -86,12 +92,15 @@ Construct an open covering by affine schemes.
                 _ = u∈kˣ
                 _ = v∈kˣ
           step2 : (x y : _) → linear-equivalent x y → x i ∈ k ˣ → y i ∈ k ˣ
-          step2 x y (c , c∈kˣ , cx≡y) xi∈kˣ = step1 c (x i) (y i) c∈kˣ xi∈kˣ (cx≡y i)
+          step2 x y (c , c∈kˣ , cx≡y) xi∈kˣ = step1 c (x i) (y i) c∈kˣ xi∈kˣ (funExt⁻ cx≡y i)
 
     embedded-𝔸ⁿ : Type ℓ
     embedded-𝔸ⁿ = Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ k.1r
 
-    module _ (k-local : isLocal k) where
+    module _
+      (k-local : isLocal k)
+      where
+
       ι : embedded-𝔸ⁿ → ℙ
       ι (x , xi≡1) = [ x , (λ x≡0 → 1≢0 (sym xi≡1 ∙ cong (λ x → x i) x≡0)) ]
         where
@@ -101,21 +110,22 @@ Construct an open covering by affine schemes.
       ι-injective (x , xi≡1) (y , yi≡1) ιx≡ιy =
         Σ≡Prop
           (λ _ → k.is-set _ _)
-          (funExt (λ j → lineq→≡ (effective (λ _ _ → {!!}) {!!} _ _ ιx≡ιy) j))
+          (lineq→≡ (effective (λ _ _ → {!!}) {!!} _ _ ιx≡ιy))
         where
-        lineq→≡ : linear-equivalent x y → (j : _) → x j ≡ y j
-        lineq→≡ (c , _ , cx≡y) j =
-          x j           ≡⟨ sym (·IdL _) ⟩
-          1r k.· x j    ≡⟨ cong (k._· _) (sym c≡1) ⟩
-          c k.· x j     ≡⟨ cx≡y j ⟩
-          y j           ∎
+        lineq→≡ : linear-equivalent x y → x ≡ y
+        lineq→≡ (c , _ , cx≡y) =
+          x        ≡⟨ sym (⋆IdL _) ⟩
+          1r ⋆ x   ≡⟨ cong (_⋆ _) (sym c≡1) ⟩
+          c ⋆ x    ≡⟨ cx≡y ⟩
+          y        ∎
           where
+          open 𝔸ⁿ⁺¹
           open k
           c≡1 : c ≡ k.1r
           c≡1 =
             c           ≡⟨ sym (·IdR _) ⟩
             c k.· 1r    ≡⟨ cong (_ k.·_) (sym xi≡1) ⟩
-            c k.· x i   ≡⟨ cx≡y i ⟩
+            c k.· x i   ≡⟨ funExt⁻ cx≡y i ⟩
             y i         ≡⟨ yi≡1 ⟩
             1r          ∎
 

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -10,15 +10,21 @@ open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_) renaming (ℙ to Powerset)
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Pointed using (_→∙_)
+open import Cubical.Foundations.Pointed.Homogeneous using (isHomogeneousDiscrete)
+open import Cubical.Foundations.Univalence using (pathToEquiv)
+
+open import Cubical.Structures.Pointed using (pointed-sip)
 
 open import Cubical.Functions.Logic using (⇒∶_⇐∶_)
 open import Cubical.Functions.Embedding
 
 open import Cubical.HITs.SetQuotients as SQ
 open import Cubical.HITs.PropositionalTruncation as PT
-open import Cubical.Data.Nat using (ℕ; _+_)
+open import Cubical.Data.Nat using (ℕ; _+_; +-comm)
 open import Cubical.Data.FinData
 open import Cubical.Data.Sigma
+open import Cubical.Data.Maybe
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRing.LocalRing
@@ -171,6 +177,20 @@ Construct an open covering by affine schemes.
                   1r ⋆ x           ≡⟨ ⋆IdL _ ⟩
                   x                ∎ ) )}
 
+    embedded-𝔸ⁿ-is-𝔸ⁿ : embedded-𝔸ⁿ ≡ 𝔸 k n
+    embedded-𝔸ⁿ-is-𝔸ⁿ =
+      embedded-𝔸ⁿ                               ≡⟨⟩
+      ((Fin (n + 1) , i) →∙ (⟨ k ⟩ , 1r))       ≡⟨ cong (_→∙ _) transformDomain ⟩
+      (Maybe∙ (Fin n) →∙ (⟨ k ⟩ , 1r))          ≡⟨ isoToPath (freelyPointedIso _ _) ⟩
+      FinVec ⟨ k ⟩ n                            ≡⟨ sym (std-affine-space-as-product k n) ⟩
+      𝔸 k n                                     ∎
+      where
+      transformDomain : (Fin (n + 1) , i) ≡ Maybe∙ (Fin n)
+      transformDomain =
+        (Fin (n + 1) , i)        ≡⟨ (pointed-sip _ _ (pathToEquiv (cong Fin (+-comm n 1)) , refl)) ⟩
+        (Fin (ℕ.suc n) , _)      ≡⟨ (isHomogeneousDiscrete discreteFin zero) ⟩
+        (Fin (ℕ.suc n) , zero)   ≡⟨ finSuc≡Maybe∙ ⟩
+        Maybe∙ (Fin n)           ∎
 
   covering : isLocal k → sqc-over-itself k → (p : ℙ) → ∃[ i ∈ Fin (n + 1) ] ⟨ fst (U i p) ⟩
   covering k-local k-sqc =

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -97,7 +97,7 @@ module _ (k : CommRing ℓ) (n : ℕ) where
     -- It doesn't seem like we need this for now.
 
   ℙ : Type _
-  ℙ = 𝔸ⁿ⁺¹-0 / (on fst linear-equivalent)
+  ℙ = 𝔸ⁿ⁺¹-0 / (pulledbackRel fst linear-equivalent)
 ```
 Construct an open covering by affine schemes.
 ```agda
@@ -143,7 +143,7 @@ Construct an open covering by affine schemes.
           (λ _ → k.is-set _ _)
           (PT.rec (𝔸ⁿ⁺¹.is-set _ _) lineq→≡ (Iso.fun (isEquivRel→TruncIso eqRel _ _) ιx≡ιy))
         where
-        eqRel = isEquivRelOn fst linear-equivalent isEquivRel-lin-eq
+        eqRel = isEquivRelPulledbackRel fst linear-equivalent isEquivRel-lin-eq
         lineq→≡ : linear-equivalent x y → x ≡ y
         lineq→≡ (c , _ , cx≡y) =
           x        ≡⟨ sym (⋆IdL _) ⟩

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -18,11 +18,13 @@ open import Cubical.Data.FinData
 open import Cubical.Data.Sigma
 
 open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
 
 open import Cubical.Relation.Nullary.Base using (¬_)
 
 open import SyntheticGeometry.Spec
 open import SyntheticGeometry.Open
+open import SyntheticGeometry.SQC
 
 private variable ℓ : Level
 
@@ -78,4 +80,10 @@ Construct an open covering by affine schemes.
               _ = v∈kˣ
         step2 : (x y : _) → linear-equivalent x y → fst x i ∈ k ˣ → fst y i ∈ k ˣ
         step2 x y (c , c∈kˣ , cx≡y) xi∈kˣ = step1 c (fst x i) (fst y i) c∈kˣ xi∈kˣ (cx≡y i)
+
+  covering : isLocal k → sqc-over-itself k → (p : ℙ) → ∃[ i ∈ Fin (n + 1) ] ⟨ fst (U i p) ⟩
+  covering k-local k-sqc =
+    SQ.elimProp
+      (λ _ → isPropPropTrunc)
+      λ x → generalized-field-property k k-local k-sqc (fst x) (snd x)
 ```

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -87,8 +87,11 @@ module _ (k : CommRing ℓ) (n : ℕ) where
           _ = c∈kˣ
           _ = d∈kˣ
 
+    -- Note: linear-equivalent is not prop-valued as a relation on 𝔸ⁿ⁺¹
+    -- but it is if we restrict to 𝔸ⁿ⁺¹-0 and assume k to be local and SQC.
+
   ℙ : Type _
-  ℙ = 𝔸ⁿ⁺¹-0 / (λ x y → linear-equivalent (fst x) (fst y))
+  ℙ = 𝔸ⁿ⁺¹-0 / (on fst linear-equivalent)
 ```
 Construct an open covering by affine schemes.
 ```agda
@@ -132,8 +135,9 @@ Construct an open covering by affine schemes.
       ι-injective (x , xi≡1) (y , yi≡1) ιx≡ιy =
         Σ≡Prop
           (λ _ → k.is-set _ _)
-          (lineq→≡ (effective (λ _ _ → {!!}) {!!} _ _ ιx≡ιy))
+          (PT.rec (𝔸ⁿ⁺¹.is-set _ _) lineq→≡ (Iso.fun (isEquivRel→TruncIso eqRel _ _) ιx≡ιy))
         where
+        eqRel = isEquivRelOn fst linear-equivalent isEquivRel-lin-eq
         lineq→≡ : linear-equivalent x y → x ≡ y
         lineq→≡ (c , _ , cx≡y) =
           x        ≡⟨ sym (⋆IdL _) ⟩

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -8,8 +8,10 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_) renaming (ℙ to Powerset)
+open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Functions.Logic using (⇒∶_⇐∶_)
+open import Cubical.Functions.Embedding
 
 open import Cubical.HITs.SetQuotients as SQ
 open import Cubical.HITs.PropositionalTruncation as PT
@@ -26,6 +28,8 @@ open import SyntheticGeometry.Spec
 open import SyntheticGeometry.Open
 open import SyntheticGeometry.SQC
 
+open import Cubical.Tactics.CommRingSolver.Reflection
+
 private variable ℓ : Level
 
 module _ (k : CommRing ℓ) (n : ℕ) where
@@ -38,48 +42,82 @@ module _ (k : CommRing ℓ) (n : ℕ) where
 
   𝔸ⁿ⁺¹-0 = Σ[ x ∈ 𝔸ⁿ⁺¹ ] ¬ (x ≡ 0𝔸ⁿ⁺¹)
 
-  linear-equivalent : (x y : 𝔸ⁿ⁺¹-0) → Type _
-  linear-equivalent (x , _) (y , _) =
+  linear-equivalent : (x y : 𝔸ⁿ⁺¹) → Type _
+  linear-equivalent x y =
     Σ[ c ∈ ⟨ k ⟩ ] (c ∈ (k ˣ)) × ((i : Fin (n + 1)) → c k.· (x i) ≡ y i)
 
-  linear-equivalence-sym : (x y : 𝔸ⁿ⁺¹-0) → linear-equivalent x y → linear-equivalent y x
+  linear-equivalence-sym : (x y : 𝔸ⁿ⁺¹) → linear-equivalent x y → linear-equivalent y x
   linear-equivalence-sym x y (c , c∈kˣ , cx≡y) =
     c⁻¹ ,
     Units.RˣInvClosed k c ,
-    λ i → c⁻¹ k.· fst y i         ≡⟨ sym (cong (c⁻¹ k.·_) (cx≡y i)) ⟩
-          c⁻¹ k.· (c k.· fst x i) ≡⟨ ·Assoc _ c _ ⟩
-          (c⁻¹ k.· c) k.· fst x i ≡⟨ cong (k._· fst x i) (Units.·-linv k c) ⟩
-          k.1r k.· fst x i        ≡⟨ ·IdL _  ⟩
-          fst x i ∎
+    λ i → c⁻¹ k.· y i          ≡⟨ sym (cong (c⁻¹ k.·_) (cx≡y i)) ⟩
+          c⁻¹ k.· (c k.· x i)  ≡⟨ ·Assoc _ c _ ⟩
+          (c⁻¹ k.· c) k.· x i  ≡⟨ cong (k._· x i) (Units.·-linv k c) ⟩
+          k.1r k.· x i         ≡⟨ ·IdL _  ⟩
+          x i                  ∎
     where
       open k
       instance _ = c∈kˣ
       c⁻¹ = fst c∈kˣ
 
   ℙ : Type _
-  ℙ = 𝔸ⁿ⁺¹-0 / linear-equivalent
+  ℙ = 𝔸ⁿ⁺¹-0 / (λ x y → linear-equivalent (fst x) (fst y))
 ```
 Construct an open covering by affine schemes.
 ```agda
+  module _
+    (i : Fin (n + 1))
+    where
 
-  U : (i : Fin (n + 1)) → ℙ → (qc-open-prop k)
-  U i = SQ.rec
-          (is-set-qc-open-prop k)
-          (λ x → simple-qc-open-prop k ((fst x) i))
-          λ x y x~y
-            → qc-open-≡
-                k _ _
-                (⇒∶ (step2 x y x~y)
-                 ⇐∶ step2 y x (linear-equivalence-sym x y x~y))
-      where
-        step1 : (u v w : ⟨ k ⟩) → (u ∈ k ˣ) → (v ∈ k ˣ) → u k.· v ≡ w → w ∈ k ˣ
-        step1 u v w u∈kˣ v∈kˣ p = subst (_∈ k ˣ) p (Units.RˣMultClosed k u v)
+    U : ℙ → (qc-open-prop k)
+    U = SQ.rec
+            (is-set-qc-open-prop k)
+            (λ x → simple-qc-open-prop k ((fst x) i))
+            λ x y x~y
+              → qc-open-≡
+                  k _ _
+                  (⇒∶ (step2 (fst x) (fst y) x~y)
+                   ⇐∶ step2 (fst y) (fst x) (linear-equivalence-sym _ _ x~y))
+        where
+          step1 : (u v w : ⟨ k ⟩) → (u ∈ k ˣ) → (v ∈ k ˣ) → u k.· v ≡ w → w ∈ k ˣ
+          step1 u v w u∈kˣ v∈kˣ p = subst (_∈ k ˣ) p (Units.RˣMultClosed k u v)
+            where
+              instance
+                _ = u∈kˣ
+                _ = v∈kˣ
+          step2 : (x y : _) → linear-equivalent x y → x i ∈ k ˣ → y i ∈ k ˣ
+          step2 x y (c , c∈kˣ , cx≡y) xi∈kˣ = step1 c (x i) (y i) c∈kˣ xi∈kˣ (cx≡y i)
+
+    embedded-𝔸ⁿ : Type ℓ
+    embedded-𝔸ⁿ = Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ k.1r
+
+    module _ (k-local : isLocal k) where
+      ι : embedded-𝔸ⁿ → ℙ
+      ι (x , xi≡1) = [ x , (λ x≡0 → 1≢0 (sym xi≡1 ∙ cong (λ x → x i) x≡0)) ]
+        where
+        open Consequences k k-local
+
+      ι-injective : (x y : embedded-𝔸ⁿ) → ι x ≡ ι y → x ≡ y
+      ι-injective (x , xi≡1) (y , yi≡1) ιx≡ιy =
+        Σ≡Prop
+          (λ _ → k.is-set _ _)
+          (funExt (λ j → lineq→≡ (effective (λ _ _ → {!!}) {!!} _ _ ιx≡ιy) j))
+        where
+        lineq→≡ : linear-equivalent x y → (j : _) → x j ≡ y j
+        lineq→≡ (c , _ , cx≡y) j =
+          x j           ≡⟨ sym (·IdL _) ⟩
+          1r k.· x j    ≡⟨ cong (k._· _) (sym c≡1) ⟩
+          c k.· x j     ≡⟨ cx≡y j ⟩
+          y j           ∎
           where
-            instance
-              _ = u∈kˣ
-              _ = v∈kˣ
-        step2 : (x y : _) → linear-equivalent x y → fst x i ∈ k ˣ → fst y i ∈ k ˣ
-        step2 x y (c , c∈kˣ , cx≡y) xi∈kˣ = step1 c (fst x i) (fst y i) c∈kˣ xi∈kˣ (cx≡y i)
+          open k
+          c≡1 : c ≡ k.1r
+          c≡1 =
+            c           ≡⟨ sym (·IdR _) ⟩
+            c k.· 1r    ≡⟨ cong (_ k.·_) (sym xi≡1) ⟩
+            c k.· x i   ≡⟨ cx≡y i ⟩
+            y i         ≡⟨ yi≡1 ⟩
+            1r          ∎
 
   covering : isLocal k → sqc-over-itself k → (p : ℙ) → ∃[ i ∈ Fin (n + 1) ] ⟨ fst (U i p) ⟩
   covering k-local k-sqc =

--- a/SyntheticGeometry/SQC.lagda.md
+++ b/SyntheticGeometry/SQC.lagda.md
@@ -9,6 +9,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset
+open import Cubical.Foundations.Function
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.Algebra
@@ -23,8 +24,10 @@ open import Cubical.Algebra.CommAlgebra.FGIdeal
 open import Cubical.Algebra.CommRingSolver.Reflection
 import Cubical.Algebra.CommAlgebra.FreeCommAlgebra as FreeCommAlgebra
 
+open import Cubical.Data.Sigma
 open import Cubical.Data.Empty
 open import Cubical.Data.FinData
+
 open import Cubical.HITs.PropositionalTruncation as Prop
 
 open import Cubical.Relation.Nullary
@@ -53,10 +56,12 @@ module _ {ℓ : Level} (k : CommRing ℓ) (k-sqc : sqc-over-itself k) where
 ```
 
 The ring k is a field in the sense that every non-zero element is invertible.
+But even more, an invertible elements exists in every nonzero vector.
 
 ```agda
-  field-property : (x : ⟨ k ⟩) → ¬(x ≡ 0r) → x ∈ k ˣ
-  field-property x x≢0 =
+  generalized-field-property : {n : _} → (xs : FinVec ⟨ k ⟩ n) → ¬(xs ≡ const 0r) → ∃[ i ∈ _ ] xs i ∈ k ˣ
+  generalized-field-property xs xs≢0 =
+    {!
     Prop.rec
       (snd ((k ˣ) x))
       (λ {(α , isLC)
@@ -65,38 +70,39 @@ The ring k is a field in the sense that every non-zero element is invertible.
            (α zero · x + 0r)   ≡⟨ sym isLC ⟩
            1r ∎)
        })
-      1∈⟨x⟩
+      1∈⟨x⟩ !}
     where
       useSolver : (x α : ⟨ k ⟩) → x · α ≡ α · x + 0r
       useSolver = solve k
 
       open FreeCommAlgebra.Construction using (const)
 
-      ⟨x⟩ : IdealsIn kₐ
-      ⟨x⟩ = generatedIdeal kₐ (replicateFinVec 1 x)
+      ⟨xs⟩ : IdealsIn kₐ
+      ⟨xs⟩ = generatedIdeal kₐ xs
 
       A : CommAlgebra k ℓ
-      A = kₐ / ⟨x⟩
+      A = kₐ / ⟨xs⟩
 
       π : CommAlgebraHom kₐ A
-      π = quotientHom kₐ ⟨x⟩
+      π = quotientHom kₐ ⟨xs⟩
 
 
       module A = CommAlgebraStr (snd A)
       module kₐ = CommAlgebraStr (snd kₐ)
 
-      πx≡0 : π $a x ≡ A.0a
-      πx≡0 = isZeroFromIdeal {A = kₐ} {I = ⟨x⟩} x
-               (incInIdeal kₐ (replicateFinVec 1 x) zero)
+      πx≡0 : (i : _) → π $a xs i ≡ A.0a
+      πx≡0 i = isZeroFromIdeal {A = kₐ} {I = ⟨xs⟩} (xs i)
+               (incInIdeal kₐ xs i)
 
       finite-presentation-of-A : FinitePresentation A
-      finite-presentation-of-A = Instances.R/⟨x⟩FP k x
+      finite-presentation-of-A = Instances.R/⟨xs⟩FP k xs
+{-
 
       equiv : ⟨ A ⟩ ≃ (Spec k A → ⟨ k ⟩)
       equiv = _ , k-sqc _ ∥_∥₁.∣ finite-presentation-of-A ∣₁
 
       Spec-A-empty : Spec k A → ⊥
-      Spec-A-empty h = x≢0 x≡0
+      Spec-A-empty h = xs≢0 xs≡0 -- TODO
         where
           open AlgebraHoms using (compAlgebraHom)
           -- We use _∘a_ (compAlgebraHom) for composition because the implicit arguments
@@ -105,12 +111,12 @@ The ring k is a field in the sense that every non-zero element is invertible.
           -- hang indefinitely.)
           id≡h∘π : idCAlgHom kₐ ≡ h ∘a π
           id≡h∘π = initialMapProp k kₐ (idCAlgHom kₐ) (h ∘a π)
-          x≡0 : x ≡ 0r
-          x≡0 =
-            x              ≡⟨ cong (_$a x) id≡h∘π ⟩
-            h $a (π $a x)  ≡⟨ cong (h $a_) πx≡0 ⟩
-            h $a A.0a      ≡⟨ IsAlgebraHom.pres0 (snd h) ⟩
-            0r             ∎
+          xs≡0 : (i : _) → xs i ≡ 0r
+          xs≡0 i =
+            xs i              ≡⟨ cong (_$a xs i) id≡h∘π ⟩
+            h $a (π $a xs i)  ≡⟨ cong (h $a_) πx≡0 ⟩
+            h $a A.0a         ≡⟨ IsAlgebraHom.pres0 (snd h) ⟩
+            0r                ∎
 
       functions-on-Spec-A-trivial : {f g : Spec k A → ⟨ k ⟩} → f ≡ g
       functions-on-Spec-A-trivial = funExt (λ p → Cubical.Data.Empty.rec (Spec-A-empty p))
@@ -121,6 +127,7 @@ The ring k is a field in the sense that every non-zero element is invertible.
       1∈kernel-π : kₐ.1a ∈ fst (kernel kₐ A π)
       1∈kernel-π = A-is-trivial
 
-      1∈⟨x⟩ : kₐ.1a ∈ fst ⟨x⟩
-      1∈⟨x⟩ = subst (λ J → kₐ.1a ∈ fst J) (kernel≡I kₐ ⟨x⟩) 1∈kernel-π
+      1∈⟨xs⟩ : kₐ.1a ∈ fst ⟨xs⟩
+      1∈⟨xs⟩ = subst (λ J → kₐ.1a ∈ fst J) (kernel≡I kₐ ⟨xs⟩) 1∈kernel-π
+-}
 ```

--- a/SyntheticGeometry/SQC.lagda.md
+++ b/SyntheticGeometry/SQC.lagda.md
@@ -86,7 +86,6 @@ But even more, an invertible elements exists in every nonzero vector.
       π : CommAlgebraHom kₐ A
       π = quotientHom kₐ ⟨xs⟩
 
-
       module A = CommAlgebraStr (snd A)
       module kₐ = CommAlgebraStr (snd kₐ)
 
@@ -96,13 +95,12 @@ But even more, an invertible elements exists in every nonzero vector.
 
       finite-presentation-of-A : FinitePresentation A
       finite-presentation-of-A = Instances.R/⟨xs⟩FP k xs
-{-
 
       equiv : ⟨ A ⟩ ≃ (Spec k A → ⟨ k ⟩)
       equiv = _ , k-sqc _ ∥_∥₁.∣ finite-presentation-of-A ∣₁
 
       Spec-A-empty : Spec k A → ⊥
-      Spec-A-empty h = xs≢0 xs≡0 -- TODO
+      Spec-A-empty h = xs≢0 (funExt xs≡0)
         where
           open AlgebraHoms using (compAlgebraHom)
           -- We use _∘a_ (compAlgebraHom) for composition because the implicit arguments
@@ -114,7 +112,7 @@ But even more, an invertible elements exists in every nonzero vector.
           xs≡0 : (i : _) → xs i ≡ 0r
           xs≡0 i =
             xs i              ≡⟨ cong (_$a xs i) id≡h∘π ⟩
-            h $a (π $a xs i)  ≡⟨ cong (h $a_) πx≡0 ⟩
+            h $a (π $a xs i)  ≡⟨ cong (h $a_) (πx≡0 i) ⟩
             h $a A.0a         ≡⟨ IsAlgebraHom.pres0 (snd h) ⟩
             0r                ∎
 
@@ -124,10 +122,17 @@ But even more, an invertible elements exists in every nonzero vector.
       A-is-trivial : {a a' : ⟨ A ⟩} → a ≡ a'
       A-is-trivial = isoFunInjective (equivToIso equiv) _ _ functions-on-Spec-A-trivial
 
-      1∈kernel-π : kₐ.1a ∈ fst (kernel kₐ A π)
-      1∈kernel-π = A-is-trivial
-
       1∈⟨xs⟩ : kₐ.1a ∈ fst ⟨xs⟩
-      1∈⟨xs⟩ = subst (λ J → kₐ.1a ∈ fst J) (kernel≡I kₐ ⟨xs⟩) 1∈kernel-π
--}
+      1∈⟨xs⟩ = subst (λ J → kₐ.1a ∈ fst J) (kernel≡I kₐ ⟨xs⟩) A-is-trivial
+
+  field-property : (x : ⟨ k ⟩) → ¬(x ≡ 0r) → x ∈ k ˣ
+  field-property x x≢0 =
+    Prop.rec
+      (snd ((k ˣ) x))
+      (λ{ (zero , x∈kˣ) → x∈kˣ})
+      (generalized-field-property (replicateFinVec 1 x) xs≢0)
+    where
+      xs≢0 : ¬ (replicateFinVec 1 x ≡ const 0r)
+      xs≢0 xs≡0 = x≢0 (cong (λ f → f zero) xs≡0)
+
 ```

--- a/SyntheticGeometry/SQC.lagda.md
+++ b/SyntheticGeometry/SQC.lagda.md
@@ -64,11 +64,6 @@ But even more, every nonzero vector contains an invertible element.
   generalized-field-property xs xs≢0 =
     Consequences.onFGIdeals k k-local xs 1∈⟨xs⟩
     where
-      useSolver : (x α : ⟨ k ⟩) → x · α ≡ α · x + 0r
-      useSolver = solve k
-
-      open FreeCommAlgebra.Construction using (const)
-
       ⟨xs⟩ : IdealsIn kₐ
       ⟨xs⟩ = generatedIdeal kₐ xs
 
@@ -82,14 +77,13 @@ But even more, every nonzero vector contains an invertible element.
       module kₐ = CommAlgebraStr (snd kₐ)
 
       πx≡0 : (i : _) → π $a xs i ≡ A.0a
-      πx≡0 i = isZeroFromIdeal {A = kₐ} {I = ⟨xs⟩} (xs i)
-               (incInIdeal kₐ xs i)
+      πx≡0 i = isZeroFromIdeal (xs i) (incInIdeal kₐ xs i)
 
       finite-presentation-of-A : FinitePresentation A
       finite-presentation-of-A = Instances.R/⟨xs⟩FP k xs
 
       equiv : ⟨ A ⟩ ≃ (Spec k A → ⟨ k ⟩)
-      equiv = _ , k-sqc _ ∥_∥₁.∣ finite-presentation-of-A ∣₁
+      equiv = _ , k-sqc A ∣ finite-presentation-of-A ∣₁
 
       Spec-A-empty : Spec k A → ⊥
       Spec-A-empty h = xs≢0 (funExt xs≡0)

--- a/SyntheticGeometry/SQC.lagda.md
+++ b/SyntheticGeometry/SQC.lagda.md
@@ -56,7 +56,7 @@ module _ {ℓ : Level} (k : CommRing ℓ) (k-sqc : sqc-over-itself k) where
 ```
 
 The ring k is a field in the sense that every non-zero element is invertible.
-But even more, an invertible elements exists in every nonzero vector.
+But even more, every nonzero vector contains an invertible element.
 
 ```agda
   generalized-field-property : {n : _} → (xs : FinVec ⟨ k ⟩ n) → ¬(xs ≡ const 0r) → ∃[ i ∈ _ ] xs i ∈ k ˣ

--- a/SyntheticGeometry/SQC.lagda.md
+++ b/SyntheticGeometry/SQC.lagda.md
@@ -12,8 +12,8 @@ open import Cubical.Foundations.Powerset
 open import Cubical.Foundations.Function
 
 open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
 open import Cubical.Algebra.Algebra
-open import Cubical.Algebra.CommRingSolver.Reflection
 open import Cubical.Algebra.CommAlgebra
 open import Cubical.Algebra.CommAlgebra.Instances.Initial
 open import Cubical.Algebra.CommAlgebra.FPAlgebra
@@ -21,7 +21,6 @@ open import Cubical.Algebra.CommAlgebra.QuotientAlgebra renaming (inducedHom to 
 open import Cubical.Algebra.CommAlgebra.Ideal
 open import Cubical.Algebra.CommAlgebra.Kernel
 open import Cubical.Algebra.CommAlgebra.FGIdeal
-open import Cubical.Algebra.CommRingSolver.Reflection
 import Cubical.Algebra.CommAlgebra.FreeCommAlgebra as FreeCommAlgebra
 
 open import Cubical.Data.Sigma
@@ -31,6 +30,8 @@ open import Cubical.Data.FinData
 open import Cubical.HITs.PropositionalTruncation as Prop
 
 open import Cubical.Relation.Nullary
+
+open import Cubical.Tactics.CommRingSolver.Reflection
 
 
 open import SyntheticGeometry.Spec
@@ -44,11 +45,11 @@ sqc-over-itself {ℓ} k = (A : CommAlgebra k ℓ) → isFPAlgebra A → isEquiv 
 
 ```
 
-Here are some properties of k that follow from its synthetic quasicoherence,
-as in Subsection 18.4.
+Here are some properties of k that follow from its synthetic quasicoherence
+together with its locality, as in Subsection 18.4.
 
 ```agda
-module _ {ℓ : Level} (k : CommRing ℓ) (k-sqc : sqc-over-itself k) where
+module _ {ℓ : Level} (k : CommRing ℓ) (k-local : isLocal k) (k-sqc : sqc-over-itself k) where
   open CommRingStr (snd k)
 
   kₐ = initialCAlg k
@@ -61,16 +62,7 @@ But even more, every nonzero vector contains an invertible element.
 ```agda
   generalized-field-property : {n : _} → (xs : FinVec ⟨ k ⟩ n) → ¬(xs ≡ const 0r) → ∃[ i ∈ _ ] xs i ∈ k ˣ
   generalized-field-property xs xs≢0 =
-    {!
-    Prop.rec
-      (snd ((k ˣ) x))
-      (λ {(α , isLC)
-        → α Fin.zero ,
-          (x · α zero          ≡⟨ useSolver x (α zero) ⟩
-           (α zero · x + 0r)   ≡⟨ sym isLC ⟩
-           1r ∎)
-       })
-      1∈⟨x⟩ !}
+    Consequences.onFGIdeals k k-local xs 1∈⟨xs⟩
     where
       useSolver : (x α : ⟨ k ⟩) → x · α ≡ α · x + 0r
       useSolver = solve k

--- a/SyntheticGeometry/Spec.lagda.md
+++ b/SyntheticGeometry/Spec.lagda.md
@@ -50,7 +50,7 @@ module _ (k : CommRing ℓ) where
     mapping-space-eq : Spec k[D] ≡ (D → ⟨ k ⟩)
     mapping-space-eq = homMapPath k-as-algebra
 
-  std-affine-space-as-product : (n : ℕ) → (𝔸 n) ≡ FinVec (fst k-as-algebra) n
+  std-affine-space-as-product : (n : ℕ) → (𝔸 n) ≡ FinVec ⟨ k ⟩ n
   std-affine-space-as-product n = mapping-space-eq (Fin n)
 
 ```


### PR DESCRIPTION
This PR completes the proof that P^n is a scheme, as far as one can complete it without defining schemes (I think). :-)

Overview:
- We define the type `embedded-𝔸ⁿ = Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ 1r`.
- We construct an embedding `ι : embedded-𝔸ⁿ → ℙ` with image `U i`.
- We show that `embedded-𝔸ⁿ` is equivalent to `𝔸ⁿ`.

This PR depends on https://github.com/felixwellen/synthetic-geometry/pull/8, although the contents of the two should be orthogonal to each other I think, sorry.