### PR TITLE
Define qc-scheme

### DIFF
--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -84,7 +84,9 @@ module _ (k : CommRing ℓ) where
 
   is-finite-qc-open-cover : {n : ℕ}
     → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
-    → Type _
-  is-finite-qc-open-cover {n = n} X U = (x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)
+    → hProp _
+  is-finite-qc-open-cover {n = n} X U =
+    ((x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)) ,
+    isPropΠ (λ _ → isPropPropTrunc)
 
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -2,7 +2,7 @@
 =================
 
 A proposition is quasicompact (qc) open iff it is logically equivalent to
-to one of f₁,...,fₙ being invertible in the base ring.
+one of f₁,...,fₙ being invertible in the base ring.
 
 ```agda
 module SyntheticGeometry.Open where

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -35,7 +35,7 @@ module _ (k : CommRing ℓ) where
   contains-invertible v = Σ[ i ∈ Fin _ ] (v i) ∈ k ˣ
 
   std-qc-open-prop : {n : ℕ} → FinVec ⟨ k ⟩ n → hProp _
-  std-qc-open-prop v = ∥ contains-invertible v ∥₁ , isPropPropTrunc
+  std-qc-open-prop v = ∥ contains-invertible v ∥ₚ
 
   is-qc-open : hProp _ → Type _
   is-qc-open P = ∃[ n ∈ ℕ ] ∃[ v ∈ FinVec ⟨ k ⟩ n ] P ≡ (std-qc-open-prop v)
@@ -67,10 +67,7 @@ module _ (k : CommRing ℓ) where
   qc-open-≡ U V = Σ≡Prop λ _ → isPropPropTrunc
 
   is-qc-open-subset : {X : Type ℓ} → Powerset X → hProp (ℓ-suc ℓ)
-  is-qc-open-subset {X = X} U = ((x : X) → is-qc-open (U x)) , is-prop
-    where
-    is-prop : isProp _
-    is-prop = isPropΠ {B = λ x → is-qc-open (U x)} λ _ → isPropPropTrunc
+  is-qc-open-subset U = ∀[ x ] is-qc-open (U x) , isPropPropTrunc
 
   qc-opens-in : (X : Type ℓ') → Type _
   qc-opens-in X = X → qc-open-prop
@@ -87,14 +84,13 @@ module _ (k : CommRing ℓ) where
     → (X : Type ℓ') → (U : Fin n → qc-opens-in X)
     → hProp _
   is-finite-qc-open-cover {n = n} X U =
-    ((x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)) ,
-    isPropΠ (λ _ → isPropPropTrunc)
+    ∀[ x ∶ X ] ∃[ i ∶ Fin n ] fst (U i x)
 
   is-affine-finite-qc-open-cover : {n : ℕ}
     → (X : Type ℓ') → (U : Fin n → qc-opens-in X)
     → hProp _
   is-affine-finite-qc-open-cover {n = n} X U =
-    fst (is-finite-qc-open-cover X U) × ((i : Fin n) → fst (is-affine k (qc-open-as-type (U i)))) ,
-    isProp× (snd (is-finite-qc-open-cover X U)) (isPropΠ λ i → snd (is-affine k (qc-open-as-type (U i))))
+    is-finite-qc-open-cover X U
+    ⊓ (∀[ i ∶ Fin n ] is-affine k (qc-open-as-type (U i)))
 
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -95,6 +95,6 @@ module _ (k : CommRing ℓ) where
     → hProp _
   is-affine-finite-qc-open-cover {n = n} X U =
     fst (is-finite-qc-open-cover X U) × ((i : Fin n) → fst (is-affine k (qc-open-as-type (U i)))) ,
-    isPropΣ (snd (is-finite-qc-open-cover X U)) λ _ → isPropΠ λ i → snd (is-affine k (qc-open-as-type (U i)))
+    isProp× (snd (is-finite-qc-open-cover X U)) (isPropΠ λ i → snd (is-affine k (qc-open-as-type (U i))))
 
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -1,4 +1,7 @@
-A proposition is quasicompact open iff it is logically equivalent to
+(qc-)Open subsets
+=================
+
+A proposition is quasicompact (qc) open iff it is logically equivalent to
 to one of f₁,...,fₙ being invertible in the base ring.
 ```agda
 module SyntheticGeometry.Open where

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -77,4 +77,9 @@ module _ (k : CommRing ℓ) where
   qc-open-as-type : {X : Type ℓ} → qc-opens-in X → Type _
   qc-open-as-type {X = X} U = Σ[ x ∈ X ] fst (fst (U x))
 
+
+  is-finite-qc-open-cover : {n : ℕ}
+    → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
+    → Type _
+  is-finite-qc-open-cover {n = n} X U = (x : X) → ∃[ i ∈ Fin n ] fst (fst (U i x))
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -74,13 +74,17 @@ module _ (k : CommRing ℓ) where
   qc-opens-in : (X : Type ℓ) → Type _
   qc-opens-in X = X → qc-open-prop
 
+  infixl 3 _∈ᵤ_
+  _∈ᵤ_ : {X : Type ℓ} → (x : X) → qc-opens-in X → Type _
+  x ∈ᵤ U = fst (fst (U x))
+
   qc-open-as-type : {X : Type ℓ} → qc-opens-in X → Type _
-  qc-open-as-type {X = X} U = Σ[ x ∈ X ] fst (fst (U x))
+  qc-open-as-type {X = X} U = Σ[ x ∈ X ] x ∈ᵤ U
 
 
   is-finite-qc-open-cover : {n : ℕ}
     → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
     → Type _
-  is-finite-qc-open-cover {n = n} X U = (x : X) → ∃[ i ∈ Fin n ] fst (fst (U i x))
+  is-finite-qc-open-cover {n = n} X U = (x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)
 
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -65,11 +65,11 @@ module _ (k : CommRing ℓ) where
     → U ≡ V
   qc-open-≡ U V = Σ≡Prop λ _ → isPropPropTrunc
 
-  is-qc-open-subset : {X : Type ℓ} → Powerset X → Type _
-  is-qc-open-subset {X = X} U = (x : X) → is-qc-open (U x)
-
-  is-prop-qc-open-subset : {X : Type ℓ} → (P : Powerset X) → isProp (is-qc-open-subset P)
-  is-prop-qc-open-subset P = isPropΠ λ _ → isPropPropTrunc
+  is-qc-open-subset : {X : Type ℓ} → Powerset X → hProp (ℓ-suc ℓ)
+  is-qc-open-subset {X = X} U = ((x : X) → is-qc-open (U x)) , is-prop
+    where
+    is-prop : isProp _
+    is-prop = isPropΠ {B = λ x → is-qc-open (U x)} λ _ → isPropPropTrunc
 
   qc-opens-in : (X : Type ℓ) → Type _
   qc-opens-in X = X → qc-open-prop
@@ -82,4 +82,5 @@ module _ (k : CommRing ℓ) where
     → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
     → Type _
   is-finite-qc-open-cover {n = n} X U = (x : X) → ∃[ i ∈ Fin n ] fst (fst (U i x))
+
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -90,11 +90,11 @@ module _ (k : CommRing ℓ) where
     ((x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)) ,
     isPropΠ (λ _ → isPropPropTrunc)
 
-  is-affine-finite-qc-open-cover : {ℓ' : Level} {n : ℕ}
+  is-affine-finite-qc-open-cover : {n : ℕ}
     → (X : Type ℓ') → (U : Fin n → qc-opens-in X)
     → hProp _
-  is-affine-finite-qc-open-cover {ℓ' = ℓ'} {n = n} X U =
-    fst (is-finite-qc-open-cover X U) × ((i : Fin n) → fst (is-affine k {ℓ' = ℓ'} (qc-open-as-type (U i)))) ,
-    isPropΣ (snd (is-finite-qc-open-cover X U)) λ _ → isPropΠ λ i → snd (is-affine k {ℓ' = ℓ'} (qc-open-as-type (U i)))
+  is-affine-finite-qc-open-cover {n = n} X U =
+    fst (is-finite-qc-open-cover X U) × ((i : Fin n) → fst (is-affine k (qc-open-as-type (U i)))) ,
+    isPropΣ (snd (is-finite-qc-open-cover X U)) λ _ → isPropΠ λ i → snd (is-affine k (qc-open-as-type (U i)))
 
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -3,6 +3,7 @@
 
 A proposition is quasicompact (qc) open iff it is logically equivalent to
 to one of f₁,...,fₙ being invertible in the base ring.
+
 ```agda
 module SyntheticGeometry.Open where
 
@@ -88,5 +89,12 @@ module _ (k : CommRing ℓ) where
   is-finite-qc-open-cover {n = n} X U =
     ((x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)) ,
     isPropΠ (λ _ → isPropPropTrunc)
+
+  is-affine-finite-qc-open-cover : {ℓ' : Level} {n : ℕ}
+    → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
+    → hProp _
+  is-affine-finite-qc-open-cover {ℓ' = ℓ'} {n = n} X U =
+    fst (is-finite-qc-open-cover X U) × ((i : Fin n) → fst (is-affine k {ℓ' = ℓ'} (qc-open-as-type (U i)))) ,
+    isPropΣ (snd (is-finite-qc-open-cover X U)) λ _ → isPropΠ λ i → snd (is-affine k {ℓ' = ℓ'} (qc-open-as-type (U i)))
 
 ```

--- a/SyntheticGeometry/Open.lagda.md
+++ b/SyntheticGeometry/Open.lagda.md
@@ -28,7 +28,7 @@ open import Cubical.Relation.Nullary.Base using (¬_)
 
 open import SyntheticGeometry.Spec
 
-private variable ℓ : Level
+private variable ℓ ℓ' : Level
 
 module _ (k : CommRing ℓ) where
   contains-invertible : {n : ℕ} → FinVec ⟨ k ⟩ n → Type _
@@ -72,26 +72,26 @@ module _ (k : CommRing ℓ) where
     is-prop : isProp _
     is-prop = isPropΠ {B = λ x → is-qc-open (U x)} λ _ → isPropPropTrunc
 
-  qc-opens-in : (X : Type ℓ) → Type _
+  qc-opens-in : (X : Type ℓ') → Type _
   qc-opens-in X = X → qc-open-prop
 
   infixl 3 _∈ᵤ_
-  _∈ᵤ_ : {X : Type ℓ} → (x : X) → qc-opens-in X → Type _
+  _∈ᵤ_ : {X : Type ℓ'} → (x : X) → qc-opens-in X → Type _
   x ∈ᵤ U = fst (fst (U x))
 
-  qc-open-as-type : {X : Type ℓ} → qc-opens-in X → Type _
+  qc-open-as-type : {X : Type ℓ'} → qc-opens-in X → Type _
   qc-open-as-type {X = X} U = Σ[ x ∈ X ] x ∈ᵤ U
 
 
   is-finite-qc-open-cover : {n : ℕ}
-    → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
+    → (X : Type ℓ') → (U : Fin n → qc-opens-in X)
     → hProp _
   is-finite-qc-open-cover {n = n} X U =
     ((x : X) → ∃[ i ∈ Fin n ] x ∈ᵤ (U i)) ,
     isPropΠ (λ _ → isPropPropTrunc)
 
   is-affine-finite-qc-open-cover : {ℓ' : Level} {n : ℕ}
-    → (X : Type ℓ) → (U : Fin n → qc-opens-in X)
+    → (X : Type ℓ') → (U : Fin n → qc-opens-in X)
     → hProp _
   is-affine-finite-qc-open-cover {ℓ' = ℓ'} {n = n} X U =
     fst (is-finite-qc-open-cover X U) × ((i : Fin n) → fst (is-affine k {ℓ' = ℓ'} (qc-open-as-type (U i)))) ,

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -105,7 +105,17 @@ module _ (k : CommRing ℓ) (n : ℕ) where
   ℙ = 𝔸ⁿ⁺¹-0 / (pulledbackRel fst linear-equivalent)
 
 ```
+
 Construct an open covering by affine schemes.
+We will fix an index i and construct U i as an qc-open by the relation
+
+ x ∈ U i ⊆ ℙⁿ ⇔ x i ∈ k ˣ
+
+For the proof that U i is equivalent to 𝔸ⁿ and therefore affine,
+we will use an intermediate type given by
+
+ embedded-𝔸 :≡ Σ[ x ∈ 𝔸ⁿ⁺¹ ] x i ≡ 1r
+
 ```agda
   module _
     (i : Fin (n + 1))

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -1,6 +1,7 @@
 Projective Space
 ================
 Construct projective space as a quotient of 𝔸ⁿ⁺¹-{0}.
+
 ```agda
 module SyntheticGeometry.ProjectiveSpace where
 
@@ -98,6 +99,7 @@ module _ (k : CommRing ℓ) (n : ℕ) where
 
   ℙ : Type _
   ℙ = 𝔸ⁿ⁺¹-0 / (pulledbackRel fst linear-equivalent)
+
 ```
 Construct an open covering by affine schemes.
 ```agda

--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -212,10 +212,7 @@ we will use an intermediate type given by
         imι⊆U' (x , xi≡1) = subst (_∈ (k ˣ)) (sym xi≡1) RˣContainsOne
 
       U⊆imι : (fst ∘ U) ⊆ im-ι-subset
-      U⊆imι x x∈U = U⊆imι' x x∈U
-        where
-        U⊆imι' : (p : ℙ) → fst (fst (U p)) → fst (im-ι-subset p)
-        U⊆imι' =
+      U⊆imι =
           elimProp
             (λ p → isProp→ (snd (im-ι-subset p)))
             λ{ (x , _) xi∈kˣ@(c , xic≡1) →
@@ -225,7 +222,6 @@ we will use an intermediate type given by
                       (x i · c) ⋆ x    ≡⟨ cong (_⋆ _) xic≡1 ⟩
                       1r ⋆ x           ≡⟨ ⋆IdL _ ⟩
                       x                ∎ ))) ∣₁}
-
 
       U≡im-ι : qc-open-as-type k U ≡ im-ι
       U≡im-ι =

--- a/SyntheticGeometry/Spec.lagda.md
+++ b/SyntheticGeometry/Spec.lagda.md
@@ -14,6 +14,7 @@ open import Cubical.Foundations.Structure
 open import Cubical.Data.Nat
 open import Cubical.Data.FinData
 open import Cubical.Data.Fin hiding (Fin)
+open import Cubical.Data.Sigma
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommAlgebra
@@ -23,11 +24,12 @@ open import Cubical.Algebra.CommAlgebra.FPAlgebra
 
 private
   variable
-    ℓ ℓ' : Level
+    ℓ ℓ' ℓ'' : Level
 
 ```
 
-The synthetic spectrum of an k-algebra A, Spec A, is a notion that makes sense internally in the Zariski Topos. We assume a ring object k in the following, which we think of as (the functor of points of) the affine line 𝔸¹.
+The synthetic spectrum of an k-algebra A, Spec A, is a notion that makes sense internally in the Zariski Topos.
+We assume a ring object k in the following, which we think of as (the functor of points of) the affine line 𝔸¹.
 
 ```agda
 
@@ -52,5 +54,8 @@ module _ (k : CommRing ℓ) where
 
   std-affine-space-as-product : (n : ℕ) → (𝔸 n) ≡ FinVec ⟨ k ⟩ n
   std-affine-space-as-product n = mapping-space-eq (Fin n)
+
+  is-affine : {ℓ' : Level} → Type ℓ'' → Type _
+  is-affine {ℓ'} X = ∃[ A ∈ (CommAlgebra k ℓ') ] X ≃ Spec A
 
 ```

--- a/SyntheticGeometry/Spec.lagda.md
+++ b/SyntheticGeometry/Spec.lagda.md
@@ -57,8 +57,8 @@ module _ (k : CommRing ℓ) where
   std-affine-space-as-product : (n : ℕ) → (𝔸 n) ≡ FinVec ⟨ k ⟩ n
   std-affine-space-as-product n = mapping-space-eq (Fin n)
 
-  is-affine : {ℓ' : Level} → Type ℓ'' → hProp _
-  is-affine {ℓ'} X =
+  is-affine : Type ℓ' → hProp _
+  is-affine {ℓ' = ℓ'} X =
     (∃[ A ∈ (CommAlgebra k ℓ') ] X ≃ Spec A) ,
     isPropPropTrunc
 

--- a/SyntheticGeometry/Spec.lagda.md
+++ b/SyntheticGeometry/Spec.lagda.md
@@ -10,11 +10,13 @@ module SyntheticGeometry.Spec where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Structure
+open import Cubical.Foundations.HLevels
 
 open import Cubical.Data.Nat
 open import Cubical.Data.FinData
 open import Cubical.Data.Fin hiding (Fin)
 open import Cubical.Data.Sigma
+open import Cubical.HITs.PropositionalTruncation
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommAlgebra
@@ -55,7 +57,9 @@ module _ (k : CommRing ℓ) where
   std-affine-space-as-product : (n : ℕ) → (𝔸 n) ≡ FinVec ⟨ k ⟩ n
   std-affine-space-as-product n = mapping-space-eq (Fin n)
 
-  is-affine : {ℓ' : Level} → Type ℓ'' → Type _
-  is-affine {ℓ'} X = ∃[ A ∈ (CommAlgebra k ℓ') ] X ≃ Spec A
+  is-affine : {ℓ' : Level} → Type ℓ'' → hProp _
+  is-affine {ℓ'} X =
+    (∃[ A ∈ (CommAlgebra k ℓ') ] X ≃ Spec A) ,
+    isPropPropTrunc
 
 ```

--- a/SyntheticGeometry/qc-Scheme.lagda.md
+++ b/SyntheticGeometry/qc-Scheme.lagda.md
@@ -17,9 +17,13 @@ open import Cubical.Data.FinData
 open import Cubical.HITs.PropositionalTruncation
 
 open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
+
 
 open import SyntheticGeometry.Open
 open import SyntheticGeometry.Spec
+open import SyntheticGeometry.ProjectiveSpace
+open import SyntheticGeometry.SQC
 
 private variable ℓ ℓ' : Level
 
@@ -35,5 +39,17 @@ module _ (k : CommRing ℓ) where
   is-qc-scheme X =
     (∃[ n ∈ ℕ ] ∃[ U ∈ (Fin n → qc-opens-in k X) ] fst (is-affine-finite-qc-open-cover k X U)) ,
     isPropPropTrunc
+
+```
+
+The projective space ℙ k n, defined [here](ProjectiveSpace.lagda.md) is a qc-scheme.
+The affine qc-open cover U k n is defined in [this](ProjectiveSpace.lagda.md) module.
+
+```agda
+
+  ℙ-is-qc-scheme : isLocal k → sqc-over-itself k
+    → (n : ℕ) → fst (is-qc-scheme (ℙ k n))
+  ℙ-is-qc-scheme k-local k-sqc n =
+    ∣ (n + 1) , ∣ (U k n) , (covering k n k-local k-sqc) , (λ i → U-is-affine k n i k-local) ∣₁ ∣₁
 
 ```

--- a/SyntheticGeometry/qc-Scheme.lagda.md
+++ b/SyntheticGeometry/qc-Scheme.lagda.md
@@ -21,7 +21,6 @@ open import Cubical.Algebra.CommRing.LocalRing
 
 
 open import SyntheticGeometry.Open
-open import SyntheticGeometry.Spec
 open import SyntheticGeometry.ProjectiveSpace
 open import SyntheticGeometry.SQC
 

--- a/SyntheticGeometry/qc-Scheme.lagda.md
+++ b/SyntheticGeometry/qc-Scheme.lagda.md
@@ -10,6 +10,7 @@ module SyntheticGeometry.qc-Scheme where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
 
 open import Cubical.Data.Nat
 open import Cubical.Data.Sigma

--- a/SyntheticGeometry/qc-Scheme.lagda.md
+++ b/SyntheticGeometry/qc-Scheme.lagda.md
@@ -1,0 +1,39 @@
+Quasi-compact schemes
+=====================
+This module defines quasi-compact (qc) schemes.
+It is easier/possible to define open subsets of quasi compact spaces.
+We will only admit (standard) finite covers, so this definition of qc-scheme could miss some qc-schemes.
+
+```agda
+module SyntheticGeometry.qc-Scheme where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Sigma
+open import Cubical.Data.FinData
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Algebra.CommRing
+
+open import SyntheticGeometry.Open
+open import SyntheticGeometry.Spec
+
+private variable ℓ ℓ' : Level
+
+```
+
+To define qc-schemes, we need the definition of open affine covers,
+defined in [Open](Open.lagda.md).
+
+```agda
+
+module _ (k : CommRing ℓ) where
+  is-qc-scheme : (X : Type ℓ') → hProp _
+  is-qc-scheme X =
+    (∃[ n ∈ ℕ ] ∃[ U ∈ (Fin n → qc-opens-in k X) ] fst (is-affine-finite-qc-open-cover k X U)) ,
+    isPropPropTrunc
+
+```

--- a/SyntheticGeometry/qc-Scheme.lagda.md
+++ b/SyntheticGeometry/qc-Scheme.lagda.md
@@ -11,6 +11,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Structure
+open import Cubical.Functions.Logic
 
 open import Cubical.Data.Nat
 open import Cubical.Data.Sigma
@@ -37,8 +38,7 @@ defined in [Open](Open.lagda.md).
 module _ (k : CommRing ℓ) where
   is-qc-scheme : (X : Type ℓ') → hProp _
   is-qc-scheme X =
-    (∃[ n ∈ ℕ ] ∃[ U ∈ (Fin n → qc-opens-in k X) ] fst (is-affine-finite-qc-open-cover k X U)) ,
-    isPropPropTrunc
+    (∃[ n ∶ ℕ ] ∃[ U ∶ (Fin n → qc-opens-in k X) ] is-affine-finite-qc-open-cover k X U)
 
 ```
 

--- a/SyntheticGeometry/qc-Scheme.lagda.md
+++ b/SyntheticGeometry/qc-Scheme.lagda.md
@@ -47,7 +47,7 @@ The affine qc-open cover U k n is defined in [this](ProjectiveSpace.lagda.md) mo
 ```agda
 
   ℙ-is-qc-scheme : isLocal k → sqc-over-itself k
-    → (n : ℕ) → fst (is-qc-scheme (ℙ k n))
+    → (n : ℕ) → ⟨ is-qc-scheme (ℙ k n) ⟩
   ℙ-is-qc-scheme k-local k-sqc n =
     ∣ (n + 1) , ∣ (U k n) , (covering k n k-local k-sqc) , (λ i → U-is-affine k n i k-local) ∣₁ ∣₁
 


### PR DESCRIPTION
This PR defines qc-schemes. The definition is a bit overly specific, but should agree with the usual one. 
The PR also finishes the construction of the finite affine qc-open cover of standard projective space (mostly by adding the necessary boilerplate). 