### PR TITLE
Constancy of functions on P^n

### DIFF
--- a/SyntheticGeometry/ProjectiveSpace.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace.lagda.md
@@ -3,6 +3,8 @@ Projective Space
 Construct projective space as a quotient of 𝔸ⁿ⁺¹-{0}.
 
 ```agda
+{-# OPTIONS --safe #-}
+
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Structure

--- a/SyntheticGeometry/ProjectiveSpace/CharacterizationOfLinearEquivalence.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/CharacterizationOfLinearEquivalence.lagda.md
@@ -5,28 +5,17 @@ We prove a slight reformulation of linear equivalence between non-zero vectors.
 ```agda
 {-# OPTIONS --safe #-}
 
--- TODO: clean up imports
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_)
-open import Cubical.Foundations.HLevels using (isProp→)
-open import Cubical.Foundations.Function using (case_of_)
 
-import Cubical.HITs.SetQuotients as SQ
 import Cubical.HITs.PropositionalTruncation as PT
 open import Cubical.Data.Nat as ℕ using (ℕ)
-open import Cubical.Data.FinData
-open import Cubical.Data.Sigma
-open import Cubical.Data.Empty as ⊥ using (⊥; isProp⊥)
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRing.LocalRing
-open import Cubical.Algebra.Ring using (module RingTheory)
 open import Cubical.Algebra.Module
 open import Cubical.Algebra.Module.Instances.FinVec
-open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
-
-open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
 
 import SyntheticGeometry.SQC
 

--- a/SyntheticGeometry/ProjectiveSpace/CharacterizationOfLinearEquivalence.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/CharacterizationOfLinearEquivalence.lagda.md
@@ -1,0 +1,61 @@
+A characterization of linear equivalence
+========================================
+We prove a slight reformulation of linear equivalence between non-zero vectors.
+
+```agda
+{-# OPTIONS --safe #-}
+
+-- TODO: clean up imports
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Powerset using (_∈_)
+open import Cubical.Foundations.HLevels using (isProp→)
+open import Cubical.Foundations.Function using (case_of_)
+
+import Cubical.HITs.SetQuotients as SQ
+import Cubical.HITs.PropositionalTruncation as PT
+open import Cubical.Data.Nat as ℕ using (ℕ)
+open import Cubical.Data.FinData
+open import Cubical.Data.Sigma
+open import Cubical.Data.Empty as ⊥ using (⊥; isProp⊥)
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
+open import Cubical.Algebra.Ring using (module RingTheory)
+open import Cubical.Algebra.Module
+open import Cubical.Algebra.Module.Instances.FinVec
+open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
+
+open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
+
+import SyntheticGeometry.SQC
+
+module SyntheticGeometry.ProjectiveSpace.CharacterizationOfLinearEquivalence
+  {ℓ : Level}
+  (k : CommRing ℓ)
+  (k-local : isLocal k)
+  (k-sqc : SyntheticGeometry.SQC.sqc-over-itself k)
+  where
+
+open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
+open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+```
+
+```agda
+module _
+  {n : ℕ}
+  ((a , a≠0) (b , b≠0) : 𝔸ⁿ⁺¹-0 n)
+  where
+
+  open LeftModuleStr (str (FinVecLeftModule (CommRing→Ring k) {n = n ℕ.+ 1}))
+  open Units k
+
+  char : (c : ⟨ k ⟩) → c ⋆ a ≡ b → linear-equivalent _ a b
+  char c ca≡b = c , c-inv , ca≡b
+    where
+      c-inv : c ∈ k ˣ
+      c-inv = PT.rec
+        (str ((k ˣ) c))
+        (λ (i , bi-inv) → fst (RˣMultDistributing c (a i) (subst (_∈ k ˣ) (sym (funExt⁻ ca≡b i)) bi-inv)))
+        (generalized-field-property b b≠0)
+```

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -5,6 +5,8 @@ assuming that all functions ℙ¹ → k are constant
 (which we did not formalize yet).
 
 ```agda
+{-# OPTIONS --safe #-}
+
 -- TODO: clean up imports
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -46,18 +46,6 @@ open import SyntheticGeometry.ProjectiveSpace.P0 k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.LineThroughPoints k k-local k-sqc
 ```
 
-We always have a base point p₀ available.
-
-```agda
-{-
-private
-  p₀ : (n : ℕ) → ℙ n
-  p₀ n = p (subst Fin (ℕ.+-comm 1 n) zero)
-    where
-    open StandardPoints
--}
-```
-
 The case n = 0 is simple.
 
 ```agda
@@ -66,10 +54,8 @@ module n=0-Case
 
   all-functions-constant :
     (f : ℙ 0 → ⟨ k ⟩) →
---    f ≡ const (f (p₀ 0))
     2-Constant f
   all-functions-constant f p q = cong f (isContr→isProp isContr-ℙ⁰ p q)
---  all-functions-constant f = funExt (λ p → cong f (isContr→isProp isContr-ℙ⁰ _ _))
 ```
 
 Let us now deduce the case n ≥ 1 from the case n = 1.
@@ -151,9 +137,7 @@ module n≥1-Case
       where
       open CommRingStr (str k) using (is-set)
 
-    all-functions-constant :
---      f ≡ const (f (p₀ n))
-      2-Constant f
+    all-functions-constant : 2-Constant f
     all-functions-constant p q = fp≡fp₀ p ∙ sym (fp≡fp₀ q)
 ```
 
@@ -164,7 +148,6 @@ all-functions-constant :
   {n : ℕ} →
   ((f : ℙ one → ⟨ k ⟩) → 2-Constant f) →
   (f : ℙ n → ⟨ k ⟩) →
---  f ≡ const (f (p₀ n))
   2-Constant f
 all-functions-constant {ℕ.zero} _ = n=0-Case.all-functions-constant
 all-functions-constant {ℕ.suc n-1} = n≥1-Case.all-functions-constant n-1

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -77,12 +77,12 @@ Let us now deduce the case n ≥ 1 from the case n = 1.
 ```agda
 equal-on-distinct-points :
   ((f : ℙ 1 → ⟨ k ⟩) → 2-Constant f) →
-  {n : ℕ} →
+  (n : ℕ) →
   (f : ℙ n → ⟨ k ⟩) →
   (p q : ℙ n) →
   ¬ (p ≡ q) →
   f p ≡ f q
-equal-on-distinct-points ℙ¹-case f p q p≢q =
+equal-on-distinct-points ℙ¹-case n f p q p≢q =
   PT.rec
     (is-set _ _)
     (λ (g , hits-p , hits-q) →
@@ -126,13 +126,35 @@ module n≥1-Case
     (f : ℙ n → ⟨ k ⟩)
     where
 
+    equal-on-distinct = equal-on-distinct-points ℙ¹-case n f
+
     fp₀≡fp₁ : f p₀ ≡ f p₁
-    fp₀≡fp₁ = equal-on-distinct-points ℙ¹-case {n = n} f p₀ p₁ (zero'≢one' ∘ pᵢ≡pⱼ→i≡j)
+    fp₀≡fp₁ = equal-on-distinct p₀ p₁ (zero'≢one' ∘ pᵢ≡pⱼ→i≡j)
+
+    fp≡fp₀ : (p : _) → f p ≡ f p₀
+    fp≡fp₀ p =
+      PT.rec
+        (is-set _ _)
+        (λ (i , Uᵢ[p]) → case (discreteFin i zero') of
+          λ{ (yes i≡zero') →
+               equal-on-distinct p p₁ (λ p≡p₁ →
+                 zero'≢one' (
+                   zero'  ≡⟨ sym i≡zero' ⟩
+                   i      ≡⟨ Uᵢ[pⱼ]→i≡j _ _ (subst (fst ∘ fst ∘ U n i) p≡p₁ Uᵢ[p]) ⟩
+                   one'   ∎))
+               ∙ sym fp₀≡fp₁
+           ; (no i≢zero') →
+               equal-on-distinct p p₀ (λ p≡p₀ →
+                 i≢zero' (Uᵢ[pⱼ]→i≡j i zero' (subst (fst ∘ fst ∘ U n i) p≡p₀ Uᵢ[p])))
+           })
+        (covering n p)
+      where
+      open CommRingStr (str k) using (is-set)
 
     all-functions-constant :
 --      f ≡ const (f (p₀ n))
       2-Constant f
-    all-functions-constant = {!!}
+    all-functions-constant p q = fp≡fp₀ p ∙ sym (fp≡fp₀ q)
 ```
 
 Here is the complete result.

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -49,11 +49,13 @@ open import SyntheticGeometry.ProjectiveSpace.LineThroughPoints k k-local k-sqc
 We always have a base point p₀ available.
 
 ```agda
+{-
 private
   p₀ : (n : ℕ) → ℙ n
   p₀ n = p (subst Fin (ℕ.+-comm 1 n) zero)
     where
     open StandardPoints
+-}
 ```
 
 The case n = 0 is simple.
@@ -99,15 +101,41 @@ module n≥1-Case
 
   n = ℕ.suc n-1
 
-  open StandardPoints {n = n}
-  p₁ = p (subst Fin (ℕ.+-comm 1 n) one)
+  sucn≡n+1 : ℕ.suc n ≡ n ℕ.+ 1
+  sucn≡n+1 = ℕ.+-comm 1 n
 
-  all-functions-constant :
-    (f : ℙ n → ⟨ k ⟩) →
---    f ≡ const (f (p₀ n))
-    2-Constant f
-  all-functions-constant f = {!!}
+  zero',one',zero'≢one' =
+    subst
+      (λ n+1 → Σ[ z ∈ Fin n+1 ] Σ[ o ∈ Fin n+1 ] ¬ (z ≡ o))
+      sucn≡n+1
+      (zero , one , znots)
+
+  zero' : Fin (n ℕ.+ 1)
+  zero' = fst zero',one',zero'≢one'
+  one' : Fin (n ℕ.+ 1)
+  one' = fst (snd zero',one',zero'≢one')
+  zero'≢one' : ¬ (zero' ≡ one')
+  zero'≢one' = snd (snd zero',one',zero'≢one')
+
+  open StandardPoints {n = n}
+  p₀ = p zero'
+  p₁ = p one'
+
+  module _
+    (ℙ¹-case : (f : ℙ 1 → ⟨ k ⟩) → 2-Constant f)
+    (f : ℙ n → ⟨ k ⟩)
+    where
+
+    fp₀≡fp₁ : f p₀ ≡ f p₁
+    fp₀≡fp₁ = equal-on-distinct-points ℙ¹-case {n = n} f p₀ p₁ (zero'≢one' ∘ pᵢ≡pⱼ→i≡j)
+
+    all-functions-constant :
+--      f ≡ const (f (p₀ n))
+      2-Constant f
+    all-functions-constant = {!!}
 ```
+
+Here is the complete result.
 
 ```agda
 all-functions-constant :
@@ -116,5 +144,6 @@ all-functions-constant :
   (f : ℙ n → ⟨ k ⟩) →
 --  f ≡ const (f (p₀ n))
   2-Constant f
-all-functions-constant ℙ¹-case f = {!!}
+all-functions-constant {ℕ.zero} _ = n=0-Case.all-functions-constant
+all-functions-constant {ℕ.suc n-1} = n≥1-Case.all-functions-constant n-1
 ```

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -46,28 +46,75 @@ open import SyntheticGeometry.ProjectiveSpace.P0 k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.LineThroughPoints k k-local k-sqc
 ```
 
+We always have a base point p₀ available.
+
+```agda
+private
+  p₀ : (n : ℕ) → ℙ n
+  p₀ n = p (subst Fin (ℕ.+-comm 1 n) zero)
+    where
+    open StandardPoints
+```
+
+The case n = 0 is simple.
+
 ```agda
 module n=0-Case
   where
 
-  open StandardPoints {n = ℕ.zero}
-  p₀ = p zero
+  all-functions-constant :
+    (f : ℙ 0 → ⟨ k ⟩) →
+--    f ≡ const (f (p₀ 0))
+    2-Constant f
+  all-functions-constant f p q = cong f (isContr→isProp isContr-ℙ⁰ p q)
+--  all-functions-constant f = funExt (λ p → cong f (isContr→isProp isContr-ℙ⁰ _ _))
+```
 
-  allFunctionsConstant :
-    (f : ℙ ℕ.zero → ⟨ k ⟩) →
-    f ≡ const (f p₀)
-  allFunctionsConstant f = funExt (λ p → cong f (isContr→isProp isContr-ℙ⁰ p p₀))
+Let us now deduce the case n ≥ 1 from the case n = 1.
 
-private
-  p₀ : {n : ℕ} → ℙ n
-  p₀ {n} = p (subst Fin (ℕ.+-comm 1 n) zero)
-    where
-    open StandardPoints
+```agda
+equal-on-distinct-points :
+  ((f : ℙ 1 → ⟨ k ⟩) → 2-Constant f) →
+  {n : ℕ} →
+  (f : ℙ n → ⟨ k ⟩) →
+  (p q : ℙ n) →
+  ¬ (p ≡ q) →
+  f p ≡ f q
+equal-on-distinct-points ℙ¹-case f p q p≢q =
+  PT.rec
+    (is-set _ _)
+    (λ (g , hits-p , hits-q) →
+      f p                ≡⟨ sym (cong f hits-p) ⟩
+      f (g (ℙ¹.p zero))  ≡⟨ ℙ¹-case (f ∘ g) _ _ ⟩
+      f (g (ℙ¹.p one))   ≡⟨ cong f hits-q ⟩
+      f q                ∎)
+    (line-through-points-exists p q p≢q)
+  where
+  open CommRingStr (str k) using (is-set)
+  module ℙ¹ = StandardPoints {n = 1}
 
-allFunctionsConstant :
+module n≥1-Case
+  (n-1 : ℕ)
+  where
+
+  n = ℕ.suc n-1
+
+  open StandardPoints {n = n}
+  p₁ = p (subst Fin (ℕ.+-comm 1 n) one)
+
+  all-functions-constant :
+    (f : ℙ n → ⟨ k ⟩) →
+--    f ≡ const (f (p₀ n))
+    2-Constant f
+  all-functions-constant f = {!!}
+```
+
+```agda
+all-functions-constant :
   {n : ℕ} →
   ((f : ℙ one → ⟨ k ⟩) → 2-Constant f) →
   (f : ℙ n → ⟨ k ⟩) →
-  f ≡ const (f p₀)
-allFunctionsConstant ℙ¹-case f = {!!}
+--  f ≡ const (f (p₀ n))
+  2-Constant f
+all-functions-constant ℙ¹-case f = {!!}
 ```

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -41,14 +41,33 @@ module SyntheticGeometry.ProjectiveSpace.ConstancyOfFunctions
 
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
 open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace.P0 k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.LineThroughPoints k k-local k-sqc
 ```
 
 ```agda
+module n=0-Case
+  where
+
+  open StandardPoints {n = ℕ.zero}
+  p₀ = p zero
+
+  allFunctionsConstant :
+    (f : ℙ ℕ.zero → ⟨ k ⟩) →
+    f ≡ const (f p₀)
+  allFunctionsConstant f = funExt (λ p → cong f (isContr→isProp isContr-ℙ⁰ p p₀))
+
+private
+  p₀ : {n : ℕ} → ℙ n
+  p₀ {n} = p (subst Fin (ℕ.+-comm 1 n) zero)
+    where
+    open StandardPoints
+
 allFunctionsConstant :
   {n : ℕ} →
   ((f : ℙ one → ⟨ k ⟩) → 2-Constant f) →
   (f : ℙ n → ⟨ k ⟩) →
-  2-Constant f
-allFunctionsConstant ℙ¹-case f p q = {!!}
+  f ≡ const (f p₀)
+allFunctionsConstant ℙ¹-case f = {!!}
 ```

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -1,0 +1,52 @@
+Constancy of functions ℙⁿ → k
+=============================
+We show that all functions ℙⁿ → k are constant,
+assuming that all functions ℙ¹ → k are constant
+(which we did not formalize yet).
+
+```agda
+-- TODO: clean up imports
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Powerset using (_∈_)
+open import Cubical.Foundations.HLevels using (isProp→)
+open import Cubical.Foundations.Function -- using (case_of_)
+
+import Cubical.HITs.SetQuotients as SQ
+import Cubical.HITs.PropositionalTruncation as PT
+open import Cubical.Data.Nat as ℕ using (ℕ)
+open import Cubical.Data.FinData
+open import Cubical.Data.Sigma
+open import Cubical.Data.Empty as ⊥ using (⊥; isProp⊥)
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
+open import Cubical.Algebra.Ring using (module RingTheory)
+open import Cubical.Algebra.Module
+open import Cubical.Algebra.Module.Instances.FinVec
+open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
+
+open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
+
+import SyntheticGeometry.SQC
+
+module SyntheticGeometry.ProjectiveSpace.ConstancyOfFunctions
+  {ℓ : Level}
+  (k : CommRing ℓ)
+  (k-local : isLocal k)
+  (k-sqc : SyntheticGeometry.SQC.sqc-over-itself k)
+  where
+
+open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
+open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace.LineThroughPoints k k-local k-sqc
+```
+
+```agda
+allFunctionsConstant :
+  {n : ℕ} →
+  ((f : ℙ one → ⟨ k ⟩) → 2-Constant f) →
+  (f : ℙ n → ⟨ k ⟩) →
+  2-Constant f
+allFunctionsConstant ℙ¹-case f p q = {!!}
+```

--- a/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/ConstancyOfFunctions.lagda.md
@@ -7,26 +7,16 @@ assuming that all functions ℙ¹ → k are constant
 ```agda
 {-# OPTIONS --safe #-}
 
--- TODO: clean up imports
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure
-open import Cubical.Foundations.Powerset using (_∈_)
-open import Cubical.Foundations.HLevels using (isProp→)
-open import Cubical.Foundations.Function -- using (case_of_)
+open import Cubical.Foundations.Function
 
-import Cubical.HITs.SetQuotients as SQ
 import Cubical.HITs.PropositionalTruncation as PT
-open import Cubical.Data.Nat as ℕ using (ℕ)
+open import Cubical.Data.Nat as ℕ using (ℕ; _+_)
 open import Cubical.Data.FinData
-open import Cubical.Data.Sigma
-open import Cubical.Data.Empty as ⊥ using (⊥; isProp⊥)
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRing.LocalRing
-open import Cubical.Algebra.Ring using (module RingTheory)
-open import Cubical.Algebra.Module
-open import Cubical.Algebra.Module.Instances.FinVec
-open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
 
 open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
 
@@ -40,7 +30,6 @@ module SyntheticGeometry.ProjectiveSpace.ConstancyOfFunctions
   where
 
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
-open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.P0 k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.LineThroughPoints k k-local k-sqc
@@ -87,7 +76,7 @@ module n≥1-Case
 
   n = ℕ.suc n-1
 
-  sucn≡n+1 : ℕ.suc n ≡ n ℕ.+ 1
+  sucn≡n+1 : ℕ.suc n ≡ n + 1
   sucn≡n+1 = ℕ.+-comm 1 n
 
   zero',one',zero'≢one' =
@@ -96,9 +85,9 @@ module n≥1-Case
       sucn≡n+1
       (zero , one , znots)
 
-  zero' : Fin (n ℕ.+ 1)
+  zero' : Fin (n + 1)
   zero' = fst zero',one',zero'≢one'
-  one' : Fin (n ℕ.+ 1)
+  one' : Fin (n + 1)
   one' = fst (snd zero',one',zero'≢one')
   zero'≢one' : ¬ (zero' ≡ one')
   zero'≢one' = snd (snd zero',one',zero'≢one')

--- a/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
@@ -40,6 +40,7 @@ module SyntheticGeometry.ProjectiveSpace.LineThroughPoints
 
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
 open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
 ```
 
 We need a slight reformulation of linear equivalence between non-zero vectors.
@@ -66,39 +67,6 @@ module CharacterizationOfLinearEquivalence
 private
   [_] : {n : ℕ} → 𝔸ⁿ⁺¹-0 n → ℙ n
   [_] = SQ.[_]
-```
-
-Here are certain "standard" points of projective space.
-
-```agda
-module StandardPoints
-  {n : ℕ}
-  where
-
-  open CommRingStr (snd k)
-
-  -- TODO: define standard basis vectors in the cubical libraries and use those instead
-  standard-basis-vector : Fin (n ℕ.+ 1) → FinVec ⟨ k ⟩ (n ℕ.+ 1)
-  standard-basis-vector i j =
-    case (discreteFin i j) of
-      λ{ (yes _) → 1r
-       ; (no _) → 0r
-       }
-
-  standard-basis-vector-1-entry : (i : _) → standard-basis-vector i i ≡ 1r
-  standard-basis-vector-1-entry i with (discreteFin i i)
-  ... | yes _ = refl
-  ... | no i≠i = ⊥.rec (i≠i refl)
-
-  p : Fin (n ℕ.+ 1) → ℙ n
-  p i =
-    [ standard-basis-vector i ,
-      (λ ≡0 → 1≢0 (
-        1r                         ≡⟨ sym (standard-basis-vector-1-entry i) ⟩
-        standard-basis-vector i i  ≡⟨ funExt⁻ ≡0 i ⟩
-        0r                         ∎ )) ]
-    where
-    open Consequences k k-local
 ```
 
 We now construct the line through two distinct points in projective space,

--- a/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
@@ -41,27 +41,7 @@ module SyntheticGeometry.ProjectiveSpace.LineThroughPoints
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
 open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
-```
-
-We need a slight reformulation of linear equivalence between non-zero vectors.
-
-```agda
-module CharacterizationOfLinearEquivalence
-  {n : ℕ}
-  ((a , a≠0) (b , b≠0) : 𝔸ⁿ⁺¹-0 n)
-  where
-
-  open LeftModuleStr (str (FinVecLeftModule (CommRing→Ring k) {n = n ℕ.+ 1}))
-  open Units k
-
-  char : (c : ⟨ k ⟩) → c ⋆ a ≡ b → linear-equivalent _ a b
-  char c ca≡b = c , c-inv , ca≡b
-    where
-      c-inv : c ∈ k ˣ
-      c-inv = PT.rec
-        (str ((k ˣ) c))
-        (λ (i , bi-inv) → fst (RˣMultDistributing c (a i) (subst (_∈ k ˣ) (sym (funExt⁻ ca≡b i)) bi-inv)))
-        (generalized-field-property b b≠0)
+open import SyntheticGeometry.ProjectiveSpace.CharacterizationOfLinearEquivalence k k-local k-sqc
 
 
 private
@@ -69,7 +49,7 @@ private
   [_] = SQ.[_]
 ```
 
-We now construct the line through two distinct points in projective space,
+We construct a line through two distinct points in projective space,
 assuming that fixed representatives for the points are given.
 
 Note:
@@ -122,7 +102,6 @@ We have to show that this intended output value is non-zero.
         module k-Th = RingTheory (CommRing→Ring k)
 
       open Units k
-      open CharacterizationOfLinearEquivalence
       open AbGroupTheory (LeftModule→AbGroup 𝔸ⁿ⁺¹-as-module)
       open ModuleTheory _ 𝔸ⁿ⁺¹-as-module
 

--- a/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
@@ -203,7 +203,7 @@ module _
   (p≠q : ¬ p ≡ q)
   where
 
-  module Std = StandardPoints {n = 1}
+  private module Std = StandardPoints {n = 1}
 
   line-through-points-exists : ∃[ l ∈ (ℙ 1 → ℙ n) ] (l (Std.p zero) ≡ p) × (l (Std.p one) ≡ q)
   line-through-points-exists =

--- a/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
@@ -5,6 +5,8 @@ we show that there exists a line in ℙⁿ interpolating between these points,
 that is, a function ℙ¹ → ℙⁿ that hits the points.
 
 ```agda
+{-# OPTIONS --safe #-}
+
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_)

--- a/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/LineThroughPoints.lagda.md
@@ -11,7 +11,6 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_)
 open import Cubical.Foundations.HLevels using (isProp→)
-open import Cubical.Foundations.Function using (case_of_)
 
 import Cubical.HITs.SetQuotients as SQ
 import Cubical.HITs.PropositionalTruncation as PT
@@ -27,7 +26,7 @@ open import Cubical.Algebra.Module
 open import Cubical.Algebra.Module.Instances.FinVec
 open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
 
-open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
+open import Cubical.Relation.Nullary.Base using (¬_)
 
 import SyntheticGeometry.SQC
 

--- a/SyntheticGeometry/ProjectiveSpace/P0.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/P0.lagda.md
@@ -25,7 +25,6 @@ open import Cubical.HITs.Pushout as Pushout
 
 -- open import Cubical.Data.FinData
 open import Cubical.Data.Sigma
-import Cubical.Data.Nat as ℕ
 open import Cubical.Data.FinData
 import Cubical.Data.Empty as ⊥
 
@@ -50,9 +49,9 @@ open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
 ```
 
 ```agda
-open StandardPoints {n = ℕ.zero}
+open StandardPoints {n = 0}
 
-isContr-ℙ⁰ : isContr (ℙ ℕ.zero)
+isContr-ℙ⁰ : isContr (ℙ 0)
 isContr-ℙ⁰ =
   p zero ,
   SQ.elimProp (λ _ → squash/ _ _) λ (x , x≢0) → sym (

--- a/SyntheticGeometry/ProjectiveSpace/P0.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/P0.lagda.md
@@ -7,25 +7,11 @@ That is probably all there is to say about ℙ⁰.
 ```agda
 {-# OPTIONS --safe #-}
 
--- TODO: clean up imports
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Structure
--- open import Cubical.Foundations.Powerset using (_∈_; _⊆_) renaming (ℙ to Powerset)
-open import Cubical.Foundations.Function
-open import Cubical.Foundations.HLevels
 
-open import Cubical.Functions.Embedding
-open import Cubical.Functions.Surjection
-open import Cubical.Functions.Involution
+import Cubical.HITs.SetQuotients as SQ
 
-open import Cubical.HITs.SetQuotients as SQ
-open import Cubical.HITs.PropositionalTruncation as PT using (∥_∥₁)
-open import Cubical.HITs.Pushout as Pushout
-
--- open import Cubical.Data.FinData
-open import Cubical.Data.Sigma
-open import Cubical.Data.FinData
+open import Cubical.Data.FinData using (zero)
 import Cubical.Data.Empty as ⊥
 
 open import Cubical.Algebra.CommRing
@@ -40,12 +26,8 @@ module SyntheticGeometry.ProjectiveSpace.P0
   (k-sqc : SyntheticGeometry.SQC.sqc-over-itself k)
   where
 
-open import SyntheticGeometry.Spec k
-open import SyntheticGeometry.Open k
-open import SyntheticGeometry.Affine k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
--- open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
 ```
 
 ```agda
@@ -54,7 +36,7 @@ open StandardPoints {n = 0}
 isContr-ℙ⁰ : isContr (ℙ 0)
 isContr-ℙ⁰ =
   p zero ,
-  SQ.elimProp (λ _ → squash/ _ _) λ (x , x≢0) → sym (
+  SQ.elimProp (λ _ → SQ.squash/ _ _) λ (x , x≢0) → sym (
     recognize-standard-point zero
       (x , x≢0)
       λ{ zero zero≢zero → ⊥.rec (zero≢zero refl) })

--- a/SyntheticGeometry/ProjectiveSpace/P0.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/P0.lagda.md
@@ -1,0 +1,62 @@
+Zero-dimensional projective space ℙ⁰ is just a point
+====================================================
+
+In HoTT terms: ℙ⁰ is contractible.
+That is probably all there is to say about ℙ⁰.
+
+```agda
+{-# OPTIONS --safe #-}
+
+-- TODO: clean up imports
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Structure
+-- open import Cubical.Foundations.Powerset using (_∈_; _⊆_) renaming (ℙ to Powerset)
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Functions.Embedding
+open import Cubical.Functions.Surjection
+open import Cubical.Functions.Involution
+
+open import Cubical.HITs.SetQuotients as SQ
+open import Cubical.HITs.PropositionalTruncation as PT using (∥_∥₁)
+open import Cubical.HITs.Pushout as Pushout
+
+-- open import Cubical.Data.FinData
+open import Cubical.Data.Sigma
+import Cubical.Data.Nat as ℕ
+open import Cubical.Data.FinData
+import Cubical.Data.Empty as ⊥
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
+
+import SyntheticGeometry.SQC
+
+module SyntheticGeometry.ProjectiveSpace.P0
+  {ℓ : Level}
+  (k : CommRing ℓ)
+  (k-local : isLocal k)
+  (k-sqc : SyntheticGeometry.SQC.sqc-over-itself k)
+  where
+
+open import SyntheticGeometry.Spec k
+open import SyntheticGeometry.Open k
+open import SyntheticGeometry.Affine k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace.StandardPoints k k-local k-sqc
+-- open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+```
+
+```agda
+open StandardPoints {n = ℕ.zero}
+
+isContr-ℙ⁰ : isContr (ℙ ℕ.zero)
+isContr-ℙ⁰ =
+  p zero ,
+  SQ.elimProp (λ _ → squash/ _ _) λ (x , x≢0) → sym (
+    recognize-standard-point zero
+      (x , x≢0)
+      λ{ zero zero≢zero → ⊥.rec (zero≢zero refl) })
+```

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -11,7 +11,7 @@ open import Cubical.Foundations.Powerset using (_∈_)
 open import Cubical.Foundations.HLevels using (isProp→)
 open import Cubical.Foundations.Function -- using (case_of_)
 
-open import Cubical.HITs.SetQuotients
+open import Cubical.HITs.SetQuotients as SQ
 import Cubical.HITs.PropositionalTruncation as PT
 open import Cubical.Data.Nat as ℕ using (ℕ)
 open import Cubical.Data.FinData
@@ -38,6 +38,7 @@ module SyntheticGeometry.ProjectiveSpace.StandardPoints
 
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
 open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+open import SyntheticGeometry.ProjectiveSpace.CharacterizationOfLinearEquivalence k k-local k-sqc
 ```
 
 Here are certain "standard" points of projective space.
@@ -49,7 +50,7 @@ module StandardPoints
 
   open CommRingStr (snd k)
 
-  -- TODO: define standard basis vectors in the cubical libraries and use those instead
+  -- TODO: define standard basis vectors in the cubical library and use those instead
   standard-basis-vector : Fin (n ℕ.+ 1) → FinVec ⟨ k ⟩ (n ℕ.+ 1)
   standard-basis-vector i j =
     case (discreteFin i j) of
@@ -67,15 +68,17 @@ module StandardPoints
   ... | yes i≡j = ⊥.elim (i≢j i≡j)
   ... | no _ = refl
 
-  p : Fin (n ℕ.+ 1) → ℙ n
-  p i =
-    [ standard-basis-vector i ,
-      (λ ≡0 → 1≢0 (
-        1r                         ≡⟨ sym (standard-basis-vector-1-entry i) ⟩
-        standard-basis-vector i i  ≡⟨ funExt⁻ ≡0 i ⟩
-        0r                         ∎ )) ]
+  standard-basis-vector-≢0 : (i : _) → ¬ standard-basis-vector i ≡ 0𝔸ⁿ⁺¹ n
+  standard-basis-vector-≢0 i ≡0 =
+    1≢0 (
+      1r                         ≡⟨ sym (standard-basis-vector-1-entry i) ⟩
+      standard-basis-vector i i  ≡⟨ funExt⁻ ≡0 i ⟩
+      0r                         ∎ )
     where
     open Consequences k k-local
+
+  p : Fin (n ℕ.+ 1) → ℙ n
+  p i = [ standard-basis-vector i , standard-basis-vector-≢0 i ]
 ```
 
 A lemma for recognizing standard points.
@@ -85,8 +88,29 @@ A lemma for recognizing standard points.
     ((x , x≢0) : 𝔸ⁿ⁺¹-0 n)
     where
 
---    recognize-standard-point : (i : _) → ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
---    recognize-standard-point i x≈0 = {!!}
+    recognize-standard-point : (i : _) → ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
+    recognize-standard-point i x≈0 =
+      sym (eq/ _ _
+        (char
+          (e i , standard-basis-vector-≢0 i)
+          (x , x≢0)
+          (x i)
+          (funExt (λ j → case (discreteFin i j) return const _ of
+            λ{ (yes i≡j) →
+                 x i · e i j  ≡⟨ cong₂ (_·_) (cong x i≡j) (cong₂ e i≡j refl) ⟩
+                 x j · e j j  ≡⟨ cong (x j ·_) (standard-basis-vector-1-entry j) ⟩
+                 x j · 1r     ≡⟨ ·IdR _ ⟩
+                 x j          ∎
+             ; (no i≢j) →
+                 x i · e i j  ≡⟨ cong (x i ·_) (standard-basis-vector-0-entry i j i≢j) ⟩
+                 x i · 0r     ≡⟨ 0RightAnnihilates _ ⟩
+                 0r           ≡⟨ sym (x≈0 j (i≢j ∘ sym)) ⟩
+                 x j          ∎
+             }))))
+      where
+      e = standard-basis-vector
+      open RingTheory (CommRing→Ring k)
+
 ```
 
 Relation with the standard open cover of ℙⁿ:

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -9,7 +9,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_)
 open import Cubical.Foundations.HLevels using (isProp→)
-open import Cubical.Foundations.Function using (case_of_)
+open import Cubical.Foundations.Function -- using (case_of_)
 
 open import Cubical.HITs.SetQuotients
 import Cubical.HITs.PropositionalTruncation as PT
@@ -62,6 +62,11 @@ module StandardPoints
   ... | yes _ = refl
   ... | no i≠i = ⊥.rec (i≠i refl)
 
+  standard-basis-vector-0-entry : (i j : _) → ¬ (i ≡ j) → standard-basis-vector i j ≡ 0r
+  standard-basis-vector-0-entry i j i≢j with (discreteFin i j)
+  ... | yes i≡j = ⊥.elim (i≢j i≡j)
+  ... | no _ = refl
+
   p : Fin (n ℕ.+ 1) → ℙ n
   p i =
     [ standard-basis-vector i ,
@@ -73,3 +78,50 @@ module StandardPoints
     open Consequences k k-local
 ```
 
+A lemma for recognizing standard points.
+
+```agda
+  module _
+    ((x , x≢0) : 𝔸ⁿ⁺¹-0 n)
+    where
+
+    recognize-standard-point : (i : _) → ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
+    recognize-standard-point i x≈0 = {!!}
+```
+
+Relation with the standard open cover of ℙⁿ:
+The i-th standard point lies only in the i-th standard open.
+
+```agda
+  Uᵢ[pᵢ] : (i : _) → ⟨ fst (U _ i (p i)) ⟩
+  Uᵢ[pᵢ] i =
+    subst (_∈ (k ˣ))
+      (sym (standard-basis-vector-1-entry i))
+      RˣContainsOne
+    where
+    open Units k
+
+  Uᵢ[pⱼ]→i≡j : (i j : _) → ⟨ fst (U _ i (p j)) ⟩ → i ≡ j
+  Uᵢ[pⱼ]→i≡j i j Uᵢ[pⱼ] =
+    case (discreteFin i j) return const (i ≡ j) of
+      λ{ (yes i≡j) → i≡j
+       ; (no i≢j) → ⊥.elim (1≢0
+           let
+           j≢i : ¬ (j ≡ i)
+           j≢i j≡i = i≢j (sym j≡i)
+           instance
+             0-inv : 0r ∈ k ˣ
+             0-inv =
+               subst (_∈ (k ˣ))
+                 (standard-basis-vector-0-entry j i j≢i)
+                 Uᵢ[pⱼ]
+           in
+           1r          ≡⟨ sym (·-rinv 0r) ⟩
+           0r · 0r ⁻¹  ≡⟨ 0LeftAnnihilates _ ⟩
+           0r          ∎)
+       }
+    where
+    open Units k
+    open Consequences k k-local
+    open RingTheory (CommRing→Ring k)
+```

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -4,26 +4,19 @@ Standard points of projective space
 ```agda
 {-# OPTIONS --safe #-}
 
--- TODO: clean up imports
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Powerset using (_∈_)
-open import Cubical.Foundations.HLevels using (isProp→)
-open import Cubical.Foundations.Function -- using (case_of_)
+open import Cubical.Foundations.Function
 
-open import Cubical.HITs.SetQuotients as SQ
-import Cubical.HITs.PropositionalTruncation as PT
+open import Cubical.HITs.SetQuotients as SQ using ([_])
 open import Cubical.Data.Nat as ℕ using (ℕ)
 open import Cubical.Data.FinData
-open import Cubical.Data.Sigma
-open import Cubical.Data.Empty as ⊥ using (⊥; isProp⊥)
+import Cubical.Data.Empty as ⊥
 
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRing.LocalRing
 open import Cubical.Algebra.Ring using (module RingTheory)
-open import Cubical.Algebra.Module
-open import Cubical.Algebra.Module.Instances.FinVec
-open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
 
 open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
 
@@ -37,7 +30,6 @@ module SyntheticGeometry.ProjectiveSpace.StandardPoints
   where
 
 open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
-open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
 open import SyntheticGeometry.ProjectiveSpace.CharacterizationOfLinearEquivalence k k-local k-sqc
 ```
 
@@ -91,7 +83,7 @@ A lemma for recognizing standard points.
 
     recognize-standard-point : ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
     recognize-standard-point x≈0 =
-      sym (eq/ _ _
+      sym (SQ.eq/ _ _
         (char
           (e i , standard-basis-vector-≢0 i)
           (x , x≢0)

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -11,7 +11,7 @@ open import Cubical.Foundations.Powerset using (_∈_)
 open import Cubical.Foundations.HLevels using (isProp→)
 open import Cubical.Foundations.Function using (case_of_)
 
-import Cubical.HITs.SetQuotients as SQ
+open import Cubical.HITs.SetQuotients
 import Cubical.HITs.PropositionalTruncation as PT
 open import Cubical.Data.Nat as ℕ using (ℕ)
 open import Cubical.Data.FinData
@@ -43,11 +43,6 @@ open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
 Here are certain "standard" points of projective space.
 
 ```agda
--- TODO: export this somewhere
-private
-  [_] : {n : ℕ} → 𝔸ⁿ⁺¹-0 n → ℙ n
-  [_] = SQ.[_]
-
 module StandardPoints
   {n : ℕ}
   where

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -150,3 +150,10 @@ The i-th standard point lies only in the i-th standard open.
     open Consequences k k-local
     open RingTheory (CommRing→Ring k)
 ```
+
+The standard points are pairwise distinct.
+
+```agda
+  pᵢ≡pⱼ→i≡j : {i j : _} → p i ≡ p j → i ≡ j
+  pᵢ≡pⱼ→i≡j {i} {j} pi≡pj = Uᵢ[pⱼ]→i≡j i j (subst (fst ∘ fst ∘ U n i) pi≡pj (Uᵢ[pᵢ] i))
+```

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -85,11 +85,12 @@ A lemma for recognizing standard points.
 
 ```agda
   module _
+    (i : Fin (n ℕ.+ 1))
     ((x , x≢0) : 𝔸ⁿ⁺¹-0 n)
     where
 
-    recognize-standard-point : (i : _) → ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
-    recognize-standard-point i x≈0 =
+    recognize-standard-point : ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
+    recognize-standard-point x≈0 =
       sym (eq/ _ _
         (char
           (e i , standard-basis-vector-≢0 i)

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -85,8 +85,8 @@ A lemma for recognizing standard points.
     ((x , x≢0) : 𝔸ⁿ⁺¹-0 n)
     where
 
-    recognize-standard-point : (i : _) → ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
-    recognize-standard-point i x≈0 = {!!}
+--    recognize-standard-point : (i : _) → ((j : _) → ¬ (j ≡ i) → x j ≡ 0r) → [ x , x≢0 ] ≡ p i
+--    recognize-standard-point i x≈0 = {!!}
 ```
 
 Relation with the standard open cover of ℙⁿ:

--- a/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
+++ b/SyntheticGeometry/ProjectiveSpace/StandardPoints.lagda.md
@@ -1,0 +1,80 @@
+Standard points of projective space
+===================================
+
+```agda
+{-# OPTIONS --safe #-}
+
+-- TODO: clean up imports
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Powerset using (_∈_)
+open import Cubical.Foundations.HLevels using (isProp→)
+open import Cubical.Foundations.Function using (case_of_)
+
+import Cubical.HITs.SetQuotients as SQ
+import Cubical.HITs.PropositionalTruncation as PT
+open import Cubical.Data.Nat as ℕ using (ℕ)
+open import Cubical.Data.FinData
+open import Cubical.Data.Sigma
+open import Cubical.Data.Empty as ⊥ using (⊥; isProp⊥)
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.LocalRing
+open import Cubical.Algebra.Ring using (module RingTheory)
+open import Cubical.Algebra.Module
+open import Cubical.Algebra.Module.Instances.FinVec
+open import Cubical.Algebra.AbGroup using (module AbGroupTheory)
+
+open import Cubical.Relation.Nullary.Base using (¬_; yes; no)
+
+import SyntheticGeometry.SQC
+
+module SyntheticGeometry.ProjectiveSpace.StandardPoints
+  {ℓ : Level}
+  (k : CommRing ℓ)
+  (k-local : isLocal k)
+  (k-sqc : SyntheticGeometry.SQC.sqc-over-itself k)
+  where
+
+open import SyntheticGeometry.ProjectiveSpace k k-local k-sqc
+open import SyntheticGeometry.SQC.Consequences k k-local k-sqc
+```
+
+Here are certain "standard" points of projective space.
+
+```agda
+-- TODO: export this somewhere
+private
+  [_] : {n : ℕ} → 𝔸ⁿ⁺¹-0 n → ℙ n
+  [_] = SQ.[_]
+
+module StandardPoints
+  {n : ℕ}
+  where
+
+  open CommRingStr (snd k)
+
+  -- TODO: define standard basis vectors in the cubical libraries and use those instead
+  standard-basis-vector : Fin (n ℕ.+ 1) → FinVec ⟨ k ⟩ (n ℕ.+ 1)
+  standard-basis-vector i j =
+    case (discreteFin i j) of
+      λ{ (yes _) → 1r
+       ; (no _) → 0r
+       }
+
+  standard-basis-vector-1-entry : (i : _) → standard-basis-vector i i ≡ 1r
+  standard-basis-vector-1-entry i with (discreteFin i i)
+  ... | yes _ = refl
+  ... | no i≠i = ⊥.rec (i≠i refl)
+
+  p : Fin (n ℕ.+ 1) → ℙ n
+  p i =
+    [ standard-basis-vector i ,
+      (λ ≡0 → 1≢0 (
+        1r                         ≡⟨ sym (standard-basis-vector-1-entry i) ⟩
+        standard-basis-vector i i  ≡⟨ funExt⁻ ≡0 i ⟩
+        0r                         ∎ )) ]
+    where
+    open Consequences k k-local
+```
+


### PR DESCRIPTION
This PR derives the fact that all functions `ℙ n → ⟨ k ⟩` are constant from the special case n = 1 (which still needs to be formalized):

```agda
all-functions-constant :
  {n : ℕ} →
  ((f : ℙ one → ⟨ k ⟩) → 2-Constant f) →
  (f : ℙ n → ⟨ k ⟩) →
  2-Constant f
```

A little bit of reorganization was necessary for this: The "characterization of linear equivalence" and "standard points" parts of the LineThroughPoints file were moved to their own files. The StandardPoints file also contains a couple of lemmas now.