### PR TITLE
adjust to cubical library (_∘a_ is not a syntax declaration any more)

### DIFF
--- a/SyntheticGeometry/SQC/Consequences.lagda.md
+++ b/SyntheticGeometry/SQC/Consequences.lagda.md
@@ -112,7 +112,7 @@ generalized-field-property xs xs≢0 =
     Spec-A-empty : Spec A → ⊥
     Spec-A-empty h = xs≢0 (funExt xs≡0)
       where
-        open AlgebraHoms using (compAlgebraHom)
+        open AlgebraHoms using (_∘a_)
         -- We use _∘a_ (compAlgebraHom) for composition because the implicit arguments
         -- of CommAlgebraHoms._∘ca_ can not be inferred. (And even using
         -- CommAlgebraHoms.compCommAlgebraHom with explicit arguments makes type checking


### PR DESCRIPTION
As pointed out by @bafain in https://github.com/felixwellen/synthetic-geometry/pull/28, this is the economic way to adjust to the change in https://github.com/agda/cubical/pull/1038.